### PR TITLE
Add Rust scaffold for gzset module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+    - run: cargo build --verbose
+    - run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "gzset"
+version = "0.1.0"
+edition = "2024"
+description = "GPU accelerated learned sorted set module for Valkey/Redis"
+license = "MIT"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+redis-module = "0.36"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # gzset
 GPU accelerated learned sorted set module for Valkey/Redis
+
+This repository now contains the initial Rust crate scaffolding for
+developing a Valkey/Redis module. The library builds as a `cdylib`
+and exposes stubbed `gzset_on_load` and `gzset_on_unload` functions
+that will be called by Valkey/Redis when the module is loaded or
+unloaded.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,30 @@
+use std::os::raw::{c_int, c_void, c_char};
+
+/// Module initialization function called by Valkey/Redis on module load.
+///
+/// This is a minimal stub that currently just returns `0` to signal
+/// successful initialization. All module setup logic will live here in
+/// the future.
+#[no_mangle]
+pub extern "C" fn gzset_on_load(
+    _ctx: *mut c_void,
+    _argv: *mut *mut c_char,
+    _argc: c_int,
+) -> c_int {
+    0
+}
+
+/// Optional unload function called when the module is unloaded.
+#[no_mangle]
+pub extern "C" fn gzset_on_unload(_ctx: *mut c_void) {
+    // Clean-up logic would go here.
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn load_returns_success() {
+        let rc = unsafe { super::gzset_on_load(std::ptr::null_mut(), std::ptr::null_mut(), 0) };
+        assert_eq!(rc, 0);
+    }
+}


### PR DESCRIPTION
## Summary
- initialize a new `gzset` Cargo library for a Valkey/Redis module
- expose stub `gzset_on_load` and `gzset_on_unload` functions
- describe the crate in the README
- add a CI workflow to build and test the crate on GitHub

## Testing
- `cargo test --offline` *(fails: no matching package named `redis-module` found)*
- `cargo test` *(fails: failed to download from `https://index.crates.io`)*


------
https://chatgpt.com/codex/tasks/task_e_685db7d947f48326bc0d60a453fa2470