### PR TITLE
Fix build by updating dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gzset"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 description = "GPU accelerated learned sorted set module for Valkey/Redis"
 license = "MIT"
 
@@ -9,4 +9,4 @@ license = "MIT"
 crate-type = ["cdylib"]
 
 [dependencies]
-redis-module = "0.36"
+redis-module = "2.0.7"


### PR DESCRIPTION
## Summary
- update rust edition and redis-module version in `Cargo.toml`

## Testing
- `cargo build --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685ede60cb1c832697284cf5df4c3d9c