### PR TITLE
Ensure integration tests build shared library

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@ unloaded.
 Run `cargo test` for unit tests.
 
 For functional tests with a Valkey instance, run `cargo integ` (or `cargo test -- --ignored`).
+The `cargo integ` alias automatically builds the `libgzset.so` shared library first via
+the `build_module` helper test so that the module is available when the integration
+tests start.

--- a/tests/build_module.rs
+++ b/tests/build_module.rs
@@ -1,0 +1,12 @@
+#[test]
+fn build_so() {
+    assert!(
+        std::path::Path::new("target/debug/libgzset.so").exists()
+            || std::process::Command::new("cargo")
+                .args(["build"])
+                .status()
+                .expect("cargo build")
+                .success(),
+        "failed to build module",
+    );
+}

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -10,9 +10,15 @@ impl ValkeyInstance {
     pub fn start() -> Self {
         let port = portpicker::pick_unused_port().expect("no free ports");
         let so_path = {
-            let debug_so = "target/debug/libgzset.so";
-            assert!(std::path::Path::new(debug_so).exists(), "{} not built", debug_so);
-            std::fs::canonicalize(debug_so).expect("canonicalize")
+            let debug = "target/debug/libgzset.so";
+            let release = "target/release/libgzset.so";
+            let path = if std::path::Path::new(release).exists() {
+                release
+            } else {
+                debug
+            };
+            assert!(std::path::Path::new(path).exists(), "{} not built", path);
+            std::fs::canonicalize(path).unwrap()
         };
 
         let child = Command::new("valkey-server")


### PR DESCRIPTION
## Summary
- add `build_module` test helper to build the `.so`
- detect release or debug artifact when starting Valkey
- document implicit build step in README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685eea46ae6c8326968379ba297b8938