### PR TITLE
Add contributor checklist and README link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# Contributor checklist for automated agents
+
+Rules for automated agents / contributors
+
+## Prerequisites
+- Install Rust toolchain with `rustup`.
+- Ensure `rustfmt` and `clippy` components are installed.
+- Have Valkey binaries (`valkey-server` and `valkey-cli`) in `PATH` for integration tests.
+
+## Standard build
+Agents must verify that a plain build succeeds:
+
+```bash
+cargo build --all-targets
+```
+
+Running with `--release` is optional but must also succeed if used.
+
+## Unit tests
+Run the unit test suite:
+
+```bash
+cargo test
+```
+
+## Integration tests
+Integration tests are executed via the cargo alias:
+
+```bash
+cargo integ
+```
+
+This builds `libgzset.so` automatically. Agents must ensure Valkey binaries are in `PATH` so the tests can start a server.
+
+## Formatting
+Code must be formatted with:
+
+```bash
+cargo fmt -- --check
+```
+
+## Lint / Clippy
+Code must pass Clippy without warnings:
+
+```bash
+cargo clippy --all-targets -- -D warnings
+```
+
+## No unchecked files
+- Ensure `git status --porcelain` shows no changes.
+- Generated files such as `Cargo.lock` must be committed when modified.
+
+## Commit message hints
+- Use imperative mood in the subject line.
+- Limit the subject to 72 characters.
+- Reference issues or PRs when relevant.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ For functional tests with a Valkey instance, run `cargo integ` (or `cargo test -
 The `cargo integ` alias automatically builds the `libgzset.so` shared library first via
 the `build_module` helper test so that the module is available when the integration
 tests start.
+
+## Contributing
+
+See [AGENTS.md](AGENTS.md) for contributor guidelines used by automated agents.

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,16 +1,23 @@
 mod helpers;
 
-use redis::Commands;
-
 #[test]
 #[ignore]
 fn gzadd_gzrank() {
     let vk = helpers::ValkeyInstance::start();
     let client = redis::Client::open(vk.url()).expect("client");
     let mut con = client.get_connection().expect("conn");
-    let add: i32 = redis::cmd("GZADD").arg("k").arg("1.0").arg("a").query(&mut con).expect("gzadd");
+    let add: i32 = redis::cmd("GZADD")
+        .arg("k")
+        .arg("1.0")
+        .arg("a")
+        .query(&mut con)
+        .expect("gzadd");
     assert_eq!(add, 1);
-    let rank: i32 = redis::cmd("GZRANK").arg("k").arg("a").query(&mut con).expect("gzrank");
+    let rank: i32 = redis::cmd("GZRANK")
+        .arg("k")
+        .arg("a")
+        .query(&mut con)
+        .expect("gzrank");
     assert_eq!(rank, 0);
     drop(vk);
 }


### PR DESCRIPTION
## Summary
- add AGENTS.md with build and test instructions for automated contributors
- link AGENTS.md from README
- fix clippy warnings

## Testing
- `cargo build --all-targets`
- `cargo build --all-targets --release`
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo integ`


------
https://chatgpt.com/codex/tasks/task_e_685ef058ddec832693a17b9fa85db3e4