### PR TITLE
Fix negative range indexes

### DIFF
--- a/tests/zset.rs
+++ b/tests/zset.rs
@@ -1744,6 +1744,20 @@ fn zrange_basics_pos_neg_withscores() {
     });
 }
 
+#[test]
+fn gzrange_negative_index_module() {
+    with_families(|ctx| {
+        if ctx.fam == Fam::Module {
+            ctx.del("zkey");
+            ctx.add("zkey", 1.0, "a").unwrap();
+            ctx.add("zkey", 2.0, "b").unwrap();
+            ctx.add("zkey", 3.0, "c").unwrap();
+            let r = ctx.range("zkey", -1, -1).unwrap();
+            assert_eq!(r, ["c"]);
+        }
+    });
+}
+
 /*
  test {ZREVRANGE basics} {
      r del zkey


### PR DESCRIPTION
## Summary
- parse signed indexes for `GZRANGE`
- register commands with correct flags
- test negative index handling for `GZRANGE`

## Testing
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings -W clippy::uninlined_format_args`
- `cargo build --all-targets`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6862e91a57108326843a7546c4082181