### PR TITLE
Fix module build detection in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,7 @@ jobs:
       run: cargo fmt -- --check
     - name: Lint
       run: cargo clippy --all-targets -- -D warnings
+    - name: Remove stale release artefacts
+      run: rm -rf target/release
     - name: Test
       run: cargo test --verbose

--- a/tests/build_module.rs
+++ b/tests/build_module.rs
@@ -1,22 +1,10 @@
+mod helpers;
+
 #[test]
 fn build_so() {
-    use std::env::consts::{DLL_PREFIX, DLL_SUFFIX};
-
-    let candidates = [
-        format!("target/release/{DLL_PREFIX}gzset{DLL_SUFFIX}"),
-        format!("target/debug/{DLL_PREFIX}gzset{DLL_SUFFIX}"),
-    ];
-
-    let mut found = candidates.iter().any(|c| std::path::Path::new(c).exists());
-
-    if !found {
-        let status = std::process::Command::new("cargo")
-            .arg("build")
-            .status()
-            .expect("cargo build");
-        assert!(status.success(), "cargo build failed");
-        found = candidates.iter().any(|c| std::path::Path::new(c).exists());
-    }
-
-    assert!(found, "failed to build module");
+    let so_path = helpers::latest_so_path();
+    assert!(
+        std::path::Path::new(&so_path).exists(),
+        "failed to build module"
+    );
 }


### PR DESCRIPTION
## Summary
- ensure test helpers load the most recent build artifact
- add command registration helper that returns errors
- clean release artifacts in CI before running tests

## Testing
- `cargo clippy --all-targets -- -D warnings -W clippy::uninlined_format_args`
- `cargo build --all-targets`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6863016b2a4883268769dc66a78a48e3