### PR TITLE
Add xtask for running valkey with module loaded

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+valkey = "run --bin xtask -- start-valkey"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,24 +7,40 @@ on:
     branches: [ master, main ]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
-    - name: Install Valkey
-      run: sudo apt-get update && sudo apt-get install -y valkey-server valkey-tools
-    - name: Build
-      run: cargo build --all-targets --verbose
-    - name: Format
-      run: cargo fmt -- --check
-    - name: Lint
-      run: cargo clippy --all-targets -- -D warnings
-    - name: Remove stale release artefacts
-      run: rm -rf target/release
-    - name: Test
-      run: cargo test --verbose
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Install Valkey
+        run: |
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            choco install valkey -y
+          else
+            sudo apt-get update && sudo apt-get install -y valkey-server valkey-tools
+          fi
+        shell: bash
+      - name: Format
+        run: cargo fmt -- --check
+        shell: bash
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+        shell: bash
+      - name: Test
+        run: cargo test --all --all-targets --verbose
+        shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v3
@@ -28,18 +25,16 @@ jobs:
           profile: minimal
           override: true
       - name: Install Valkey
-        run: |
-          if [ "${{ runner.os }}" = "Windows" ]; then
-            choco install valkey -y
-          else
-            sudo apt-get update && sudo apt-get install -y valkey-server valkey-tools
-          fi
+        run: sudo apt-get update && sudo apt-get install -y valkey-server valkey-tools
         shell: bash
       - name: Format
         run: cargo fmt -- --check
         shell: bash
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings
+        shell: bash
+      - name: Check duplicates
+        run: cargo tree -d
         shell: bash
       - name: Test
         run: cargo test --all --all-targets --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "heck 0.5.0",
  "once_cell",
  "ordered-float",
  "portpicker",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +180,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote 1.0.40",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,12 +319,15 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 name = "gzset"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "clap",
  "once_cell",
  "ordered-float",
  "portpicker",
  "quickcheck",
  "redis",
  "redis-module",
+ "which",
 ]
 
 [[package]]
@@ -230,6 +335,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "home"
@@ -346,6 +457,12 @@ dependencies = [
  "icu_normalizer",
  "icu_properties",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -504,6 +621,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "ordered-float"
@@ -805,12 +928,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote 1.0.40",
  "rustversion",
@@ -908,6 +1037,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,9 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 portpicker = "0.1"
 redis = "0.25"
+heck = "0.5"
 
 [dev-dependencies]
 quickcheck = "1"
 which = "4"
 
-[alias]
-valkey = "run --bin xtask -- start-valkey"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,19 +2,28 @@
 name = "gzset"
 version = "0.1.0"
 edition = "2021"
-description = "GPU accelerated learned sorted set module for Valkey/Redis"
 license = "MIT"
+description = "GPU accelerated learned sorted set module for Valkey/Redis"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[[bin]]
+name = "xtask"
+path = "src/bin/xtask.rs"
 
 [dependencies]
 redis-module = "2.0.7"
 once_cell = "1"
 ordered-float = "2"
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+portpicker = "0.1"
+redis = "0.25"
 
 [dev-dependencies]
-redis = "0.25"
-portpicker = "0.1"
 quickcheck = "1"
+which = "4"
 
+[alias]
+valkey = "run --bin xtask -- start-valkey"

--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@ automatically build the `libgzset.so` shared library via the `build_module` help
 ## Prerequisites
 
 `valkey-server` must be available in `PATH` for `cargo valkey` and the test suite.
+On Ubuntu run `sudo apt-get install -y valkey-server valkey-tools`. On macOS use
+`brew install valkey`.
 
 ## Quick start
 
+The `cargo valkey` alias is defined in `.cargo/config.toml`.
 Start a local server with the module pre-loaded:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ unloaded.
 Run `cargo test` to execute the full test suite. The tests start a Valkey instance and
 automatically build the `libgzset.so` shared library via the `build_module` helper.
 
+## Prerequisites
+
+`valkey-server` must be available in `PATH` for `cargo valkey` and the test suite.
+
+## Quick start
+
+Start a local server with the module pre-loaded:
+
+```bash
+cargo valkey -- --loglevel warning
+```
+
 ## Contributing
 
 See [AGENTS.md](AGENTS.md) for contributor guidelines used by automated agents.

--- a/src/bin/xtask.rs
+++ b/src/bin/xtask.rs
@@ -1,0 +1,119 @@
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use std::{
+    env,
+    path::Path,
+    process::{Command, Stdio},
+    thread,
+    time::Duration,
+};
+
+#[derive(Parser)]
+#[command(author, version, about)]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// Build libgzset and launch valkey-server with the module pre-loaded.
+    StartValkey {
+        /// debug (default) or release
+        #[arg(long, default_value = "debug")]
+        profile: Profile,
+        /// Optional fixed port. If omitted an unused one is picked automatically.
+        #[arg(long)]
+        port: Option<u16>,
+        /// Extra arguments forwarded verbatim to valkey-server
+        #[arg(trailing_var_arg = true)]
+        args: Vec<String>,
+    },
+}
+
+#[derive(clap::ValueEnum, Clone)]
+enum Profile {
+    Debug,
+    Release,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.cmd {
+        Cmd::StartValkey {
+            profile,
+            port,
+            args,
+        } => start_valkey(profile, port, &args),
+    }
+}
+
+fn start_valkey(profile: Profile, port_opt: Option<u16>, extra_args: &[String]) -> Result<()> {
+    let profile_flag = match profile {
+        Profile::Debug => "debug",
+        Profile::Release => "release",
+    };
+
+    // 1) Build the module ----------------------------------------------------
+    let mut build = Command::new("cargo");
+    build.arg("build").arg("--package=gzset");
+    if matches!(profile, Profile::Release) {
+        build.arg("--release");
+    }
+    anyhow::ensure!(build.status()?.success(), "cargo build failed");
+
+    // 2) Resolve full path to the .so/.dylib/.dll ----------------------------
+    let so_name = format!(
+        "{}gzset{}",
+        env::consts::DLL_PREFIX,
+        env::consts::DLL_SUFFIX
+    );
+    let so_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join(profile_flag)
+        .join(&so_name);
+    anyhow::ensure!(so_path.exists(), "module not found at {so_path:?}");
+
+    // 3) Pick a port ----------------------------------------------------------
+    let port = port_opt.unwrap_or_else(|| portpicker::pick_unused_port().expect("no free ports"));
+
+    // 4) Spawn valkey-server --------------------------------------------------
+    let mut cmd = Command::new("valkey-server");
+    cmd.arg("--port")
+        .arg(port.to_string())
+        .arg("--loadmodule")
+        .arg(&so_path)
+        .arg("--save")
+        .arg("") // disable RDB
+        .arg("--daemonize")
+        .arg("no")
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+
+    // pass-through additional flags
+    cmd.args(extra_args);
+
+    let mut child = cmd.spawn().context("failed to start valkey-server")?;
+
+    // 5) Wait until server is up (health probe)
+    for _ in 0..20u8 {
+        if redis::Client::open(format!("redis://127.0.0.1:{port}"))
+            .and_then(|c| c.get_connection())
+            .and_then(|mut con| redis::cmd("PING").query::<String>(&mut con))
+            .map(|p| p == "PONG")
+            .unwrap_or(false)
+        {
+            println!("=> launching valkey-server on port {port}");
+            println!("=> module path         {}", so_path.display());
+            println!("=> redis url           redis://127.0.0.1:{port}");
+            println!("⇧ press Ctrl-C to stop");
+            let status = child.wait()?;
+            anyhow::bail!("valkey-server exited with status {status}");
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    let _ = child.kill();
+    anyhow::bail!("valkey-server failed to start");
+}
+

--- a/src/bin/xtask.rs
+++ b/src/bin/xtask.rs
@@ -97,7 +97,7 @@ fn start_valkey(profile: Profile, port_opt: Option<u16>, extra_args: &[String]) 
     let mut child = cmd.spawn().context("failed to start valkey-server")?;
 
     // 5) Wait until server is up (health probe)
-    for _ in 0..20u8 {
+    for _ in 0..50u8 {
         if redis::Client::open(format!("redis://127.0.0.1:{port}"))
             .and_then(|c| c.get_connection())
             .and_then(|mut con| redis::cmd("PING").query::<String>(&mut con))
@@ -116,4 +116,3 @@ fn start_valkey(profile: Profile, port_opt: Option<u16>, extra_args: &[String]) 
     let _ = child.kill();
     anyhow::bail!("valkey-server failed to start");
 }
-

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -4,12 +4,14 @@ use std::{thread, time::Duration};
 
 pub fn latest_so_path() -> std::path::PathBuf {
     use std::env::consts::{DLL_PREFIX, DLL_SUFFIX};
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
 
-    let debug = format!("target/debug/{DLL_PREFIX}gzset{DLL_SUFFIX}");
-    let release = format!("target/release/{DLL_PREFIX}gzset{DLL_SUFFIX}");
+    let debug = root.join(format!("target/debug/{DLL_PREFIX}gzset{DLL_SUFFIX}"));
+    let release = root.join(format!("target/release/{DLL_PREFIX}gzset{DLL_SUFFIX}"));
 
-    if !Path::new(&debug).exists() {
+    if !debug.exists() {
         assert!(Command::new("cargo")
+            .current_dir(root)
             .arg("build")
             .status()
             .expect("failed to run cargo build")
@@ -21,9 +23,9 @@ pub fn latest_so_path() -> std::path::PathBuf {
 
     match meta_rel {
         Some(m_rel) if m_rel.modified().unwrap() > meta_dbg.modified().unwrap() => {
-            Path::new(&release).canonicalize().unwrap()
+            release.canonicalize().unwrap()
         }
-        _ => Path::new(&debug).canonicalize().unwrap(),
+        _ => debug.canonicalize().unwrap(),
     }
 }
 

--- a/tests/launch_valkey.rs
+++ b/tests/launch_valkey.rs
@@ -1,0 +1,53 @@
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn valkey_in_path() -> bool {
+    which::which("valkey-server").is_ok()
+}
+
+#[test]
+fn launch_valkey() -> Result<(), Box<dyn std::error::Error>> {
+    if !valkey_in_path() {
+        eprintln!("valkey-server not found in PATH; skipping");
+        return Ok(());
+    }
+    let port = portpicker::pick_unused_port().expect("no free ports");
+    let mut child = Command::new("cargo")
+        .arg("run")
+        .arg("--bin")
+        .arg("xtask")
+        .arg("--")
+        .arg("start-valkey")
+        .arg("--profile")
+        .arg("debug")
+        .arg("--port")
+        .arg(port.to_string())
+        .spawn()?;
+
+    let start = Instant::now();
+    let client = redis::Client::open(format!("redis://127.0.0.1:{port}"))?;
+    loop {
+        if let Ok(mut con) = client.get_connection() {
+            if let Ok(pong) = redis::cmd("PING").query::<String>(&mut con) {
+                if pong == "PONG" {
+                    break;
+                }
+            }
+        }
+        if start.elapsed() > Duration::from_secs(10) {
+            child.kill().ok();
+            panic!("valkey-server did not start in time");
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    Command::new("valkey-cli")
+        .arg("-p")
+        .arg(port.to_string())
+        .arg("shutdown")
+        .arg("nosave")
+        .status()?;
+    let status = child.wait()?;
+    assert!(!status.success());
+    Ok(())
+}

--- a/tests/launch_valkey.rs
+++ b/tests/launch_valkey.rs
@@ -34,7 +34,7 @@ fn launch_valkey() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
         }
-        if start.elapsed() > Duration::from_secs(10) {
+        if start.elapsed() > Duration::from_secs(5) {
             child.kill().ok();
             panic!("valkey-server did not start in time");
         }


### PR DESCRIPTION
## Summary
Added the xtask start-valkey implementation with a health probe loop and foreground server execution

## Testing
- `cargo build --all-targets`
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings -W clippy::uninlined_format_args`
- `cargo test --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68643f5b3fd48326bca9c7c6bf842ba4