### PR TITLE
Implement ZPOP, ZRAND, and scan utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,7 @@ dependencies = [
  "ordered-float",
  "portpicker",
  "quickcheck",
+ "rand",
  "redis",
  "redis-module",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib", "rlib"]
 redis-module = "2.0.7"
 once_cell = "1"
 ordered-float = "2"
+rand = "0.8"
 
 [dev-dependencies]
 redis = "0.25"


### PR DESCRIPTION
## Summary
- implement popmin/popmax, randmember and scan for module
- refresh tests and remove BuiltIn guards
- fix random selection patterns and update imports

## Testing
- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings -W clippy::uninlined_format_args`
- `cargo build --all-targets`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68643ee93ff08326b2ddad33738a3952