### PR TITLE
Improve xtask port handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Start a local server with the module pre-loaded:
 cargo valkey -- --loglevel warning
 ```
 
+## Connecting to the correct port
+
+`cargo valkey` defaults to port 6379 when it is free. If that port is already
+occupied, a random free port is chosen and printed to the terminal. Pass
+`--port 6379` or use `--force-kill` to automatically replace any old server and
+ensure the module listens on the standard port.
+
 ## Contributing
 
 See [AGENTS.md](AGENTS.md) for contributor guidelines used by automated agents.

--- a/src/bin/xtask.rs
+++ b/src/bin/xtask.rs
@@ -8,6 +8,41 @@ use std::{
     time::Duration,
 };
 
+const DEFAULT_PORT: u16 = 6379;
+
+fn occupant_info(port: u16) -> Option<(u32, String)> {
+    #[cfg(target_os = "linux")]
+    {
+        let out = Command::new("lsof")
+            .args(["-i", &format!(":{port}"), "-sTCP:LISTEN", "-t"])
+            .output()
+            .ok()?;
+        let pid = String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .next()?
+            .trim()
+            .parse::<u32>()
+            .ok()?;
+        let exe = std::fs::read_link(format!("/proc/{pid}/exe")).ok()?;
+        Some((pid, exe.display().to_string()))
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let out = Command::new("lsof")
+            .args(["-i", &format!(":{port}")])
+            .output()
+            .ok()?;
+        let line = String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .skip(1)
+            .next()?;
+        let mut parts = line.split_whitespace();
+        let cmd = parts.next()?.to_string();
+        let pid = parts.next()?.parse().ok()?;
+        Some((pid, cmd))
+    }
+}
+
 #[derive(Parser)]
 #[command(author, version, about)]
 struct Cli {
@@ -25,6 +60,9 @@ enum Cmd {
         /// Optional fixed port. If omitted an unused one is picked automatically.
         #[arg(long)]
         port: Option<u16>,
+        /// Kill any existing valkey on port 6379 before starting
+        #[arg(long)]
+        force_kill: bool,
         /// Extra arguments forwarded verbatim to valkey-server
         #[arg(trailing_var_arg = true)]
         args: Vec<String>,
@@ -43,12 +81,18 @@ fn main() -> Result<()> {
         Cmd::StartValkey {
             profile,
             port,
+            force_kill,
             args,
-        } => start_valkey(profile, port, &args),
+        } => start_valkey(profile, port, force_kill, &args),
     }
 }
 
-fn start_valkey(profile: Profile, port_opt: Option<u16>, extra_args: &[String]) -> Result<()> {
+fn start_valkey(
+    profile: Profile,
+    port_opt: Option<u16>,
+    force_kill: bool,
+    extra_args: &[String],
+) -> Result<()> {
     let profile_flag = match profile {
         Profile::Debug => "debug",
         Profile::Release => "release",
@@ -74,10 +118,44 @@ fn start_valkey(profile: Profile, port_opt: Option<u16>, extra_args: &[String]) 
         .join(&so_name);
     anyhow::ensure!(so_path.exists(), "module not found at {so_path:?}");
 
-    // 3) Pick a port ----------------------------------------------------------
-    let port = port_opt.unwrap_or_else(|| portpicker::pick_unused_port().expect("no free ports"));
+    // 3) Stop previous server if requested -----------------------------------
+    if force_kill && port_opt.unwrap_or(DEFAULT_PORT) == DEFAULT_PORT {
+        if let Some((pid, exe)) = occupant_info(DEFAULT_PORT) {
+            eprintln!("=> terminating process on port {DEFAULT_PORT}: PID {pid} ({exe})");
+            let _ = Command::new("valkey-cli")
+                .arg("-p")
+                .arg(DEFAULT_PORT.to_string())
+                .arg("shutdown")
+                .arg("nosave")
+                .status();
+            let _ = Command::new("kill").arg("-9").arg(pid.to_string()).status();
+            for _ in 0..10 {
+                if portpicker::is_free(DEFAULT_PORT) {
+                    break;
+                }
+                thread::sleep(Duration::from_millis(100));
+            }
+        }
+    }
 
-    // 4) Spawn valkey-server --------------------------------------------------
+    // 4) Pick a port ----------------------------------------------------------
+    let port = if let Some(p) = port_opt {
+        p
+    } else if portpicker::is_free(DEFAULT_PORT) {
+        DEFAULT_PORT
+    } else {
+        let fallback = portpicker::pick_unused_port().expect("no free ports");
+        if let Some((pid, exe)) = occupant_info(DEFAULT_PORT) {
+            eprintln!(
+                "*** WARNING: port {DEFAULT_PORT} in use by PID {pid} ({exe}). Using port {fallback}"
+            );
+        } else {
+            eprintln!("*** WARNING: port {DEFAULT_PORT} in use. Using port {fallback}");
+        }
+        fallback
+    };
+
+    // 5) Spawn valkey-server --------------------------------------------------
     let mut cmd = Command::new("valkey-server");
     cmd.arg("--port")
         .arg(port.to_string())

--- a/tests/gzpopmin.rs
+++ b/tests/gzpopmin.rs
@@ -1,0 +1,19 @@
+mod helpers;
+
+#[test]
+fn gzpopmin_registered() -> redis::RedisResult<()> {
+    let vk = helpers::ValkeyInstance::start();
+    let mut con = redis::Client::open(vk.url())?.get_connection()?;
+
+    // prepare
+    redis::cmd("GZADD")
+        .arg("s")
+        .arg(1)
+        .arg("a")
+        .execute(&mut con);
+
+    // must succeed
+    let res: Vec<String> = redis::cmd("GZPOPMIN").arg("s").query(&mut con)?;
+    assert_eq!(res, vec!["a".to_string(), "1".to_string()]);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- default `cargo valkey` to port 6379 if free
- warn and select a fallback port when 6379 is busy
- add `--force-kill` to replace an old server
- document choosing the right port
- test `GZPOPMIN` command

## Testing
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings -W clippy::uninlined_format_args`
- `cargo build --all-targets`
- `cargo test --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_686467a45a64832684beb2b6fd2116f8