### PR TITLE
Fix build on non-Linux platforms

### DIFF
--- a/src/bin/xtask.rs
+++ b/src/bin/xtask.rs
@@ -32,10 +32,8 @@ fn occupant_info(port: u16) -> Option<(u32, String)> {
             .args(["-i", &format!(":{port}")])
             .output()
             .ok()?;
-        let line = String::from_utf8_lossy(&out.stdout)
-            .lines()
-            .skip(1)
-            .next()?;
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let line = stdout.lines().skip(1).next()?;
         let mut parts = line.split_whitespace();
         let cmd = parts.next()?.to_string();
         let pid = parts.next()?.parse().ok()?;

--- a/tests/compile/occupant.rs
+++ b/tests/compile/occupant.rs
@@ -1,0 +1,9 @@
+fn occupant_info(out: std::process::Output) -> Option<(u32, String)> {
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let line = stdout.lines().skip(1).next()?;
+    let mut parts = line.split_whitespace();
+    let cmd = parts.next()?.to_string();
+    let pid = parts.next()?.parse().ok()?;
+    Some((pid, cmd))
+}
+fn main() {}

--- a/tests/compile_test.rs
+++ b/tests/compile_test.rs
@@ -1,0 +1,12 @@
+#[test]
+fn occupant_info_compiles() {
+    let out = std::process::Command::new("rustc")
+        .args(["tests/compile/occupant.rs", "-o", "/tmp/occupant_test"])
+        .output()
+        .expect("failed to run rustc");
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}


### PR DESCRIPTION
## Summary
- fix dangling reference in `occupant_info`
- add compile test exercising the snippet to prevent regressions

## Testing
- `cargo build --all-targets`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings -W clippy::uninlined_format_args`


------
https://chatgpt.com/codex/tasks/task_e_686576c5e2e08326a79b0ac4bea7b71c