### PR TITLE
Improve gzset concurrency

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [alias]
-valkey = "run --bin xtask -- start-valkey"
+valkey = "run --bin xtask -- start-valkey --profile release"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+- Replaced global mutex with sharded `DashMap` and per-key `RwLock`.
+- Read-only commands are registered with `readonly` flag instead of `readonly fast`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,9 +146,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "shlex",
 ]
@@ -233,6 +233,19 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -321,6 +334,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "dashmap",
  "heck 0.5.0",
  "once_cell",
  "ordered-float",
@@ -331,6 +345,12 @@ dependencies = [
  "redis-module",
  "which",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
@@ -533,6 +553,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +667,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits 0.2.19",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -810,6 +853,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,6 +926,12 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/bin/xtask.rs"
 redis-module = "2.0.7"
 once_cell = "1"
 ordered-float = "2"
+dashmap = "5"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 portpicker = "0.1"

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Differences from core Redis:
       │                       │
       │  • GZADD… commands    │
       │  • B‑tree per key     │
-      │  • Global mutex map   │
+      │  • DashMap shards     │
       └───────────┬───────────┘
                   │
       ┌───────────▼───────────┐
@@ -119,12 +119,12 @@ Differences from core Redis:
       └───────────────────────┘
 ```
 
-A simple global `Mutex<BTreeMap>` is fine for functional testing; future
-work will:
+A simple global `Mutex<BTreeMap>` was fine for functional testing but has
+been replaced by a sharded `DashMap` with per‑key `RwLock`s.
+Future work will:
 
-1. Replace the mutex with per‑key sharding or `dashmap`.
-2. Add RDB/AOF serialization hooks.
-3. Swap the B‑tree for a *learned index* backed by GPU inference.
+1. Add RDB/AOF serialization hooks.
+2. Swap the B‑tree for a *learned index* backed by GPU inference.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ server already listening on 6379.
 | `cargo clippy --all-targets` | Lint (warnings are *errors* in CI)                |
 | `cargo fmt -- --check`       | Format check                                      |
 
+First-time runs may take a while as Cargo compiles the `xtask` helper.
+Run `cargo build --all-targets` before `cargo test` to prime the cache and prevent launch timeouts.
+
 The GitHub Actions workflow replicates the above on *ubuntu‑latest*.
 
 ### Prerequisites

--- a/tests/fuzz.rs
+++ b/tests/fuzz.rs
@@ -5,7 +5,7 @@ quickcheck! {
     fn insert_remove_roundtrip(pairs: Vec<(f64, String)>) -> bool {
         let mut set = ScoreSet::default();
         for (s, m) in &pairs {
-            set.insert(*s, m.clone());
+            set.insert(*s, m);
         }
         for (_, m) in &pairs {
             assert!(set.score(m).is_some());

--- a/tests/launch_valkey.rs
+++ b/tests/launch_valkey.rs
@@ -34,7 +34,7 @@ fn launch_valkey() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
         }
-        if start.elapsed() > Duration::from_secs(5) {
+        if start.elapsed() > Duration::from_secs(30) {
             child.kill().ok();
             panic!("valkey-server did not start in time");
         }


### PR DESCRIPTION
## Summary
- shard sets with DashMap and per-key RwLock
- update architecture docs and add changelog
- build xtask in release by default
- adjust tests for new API
- fix deadlocks in write paths and use `readonly` flags

## Testing
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings -W clippy::uninlined_format_args`
- `cargo build --all-targets`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686c12ea4dc483268441ff69999bc914