### PR TITLE
Drop DashMap in favor of single-threaded HashMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
 ## Unreleased
-- Replaced global mutex with sharded `DashMap` and per-key `RwLock`.
+- Removed DashMap concurrency layer. The module now keeps state in a
+  thread-local `RefCell<HashMap>` and assumes single-threaded execution.
 - Read-only commands are registered with `readonly` flag instead of `readonly fast`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,19 +236,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,7 +321,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "dashmap",
  "heck 0.5.0",
  "once_cell",
  "ordered-float",
@@ -345,12 +331,6 @@ dependencies = [
  "redis-module",
  "which",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
@@ -553,16 +533,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
-name = "lock_api"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,19 +637,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits 0.2.19",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -853,15 +810,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
-dependencies = [
- "bitflags 2.9.1",
-]
-
-[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,12 +874,6 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/bin/xtask.rs"
 redis-module = "2.0.7"
 once_cell = "1"
 ordered-float = "2"
-dashmap = "5"
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 portpicker = "0.1"

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Differences from core Redis:
       │                       │
       │  • GZADD… commands    │
       │  • B‑tree per key     │
-      │  • DashMap shards     │
+      │  • Global RefCell<HashMap> (thread-local) │
       └───────────┬───────────┘
                   │
       ┌───────────▼───────────┐
@@ -122,8 +122,9 @@ Differences from core Redis:
       └───────────────────────┘
 ```
 
-A simple global `Mutex<BTreeMap>` was fine for functional testing but has
-been replaced by a sharded `DashMap` with per‑key `RwLock`s.
+Early prototypes used a global `Mutex<BTreeMap>`.  The crate now keeps its
+state in a thread-local `RefCell<HashMap>`, relying on Valkey to call module
+commands from a single thread.
 Future work will:
 
 1. Add RDB/AOF serialization hooks.

--- a/src/sets.rs
+++ b/src/sets.rs
@@ -1,0 +1,36 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use crate::ScoreSet;
+
+thread_local! {
+    static SETS: RefCell<HashMap<String, ScoreSet>> = RefCell::new(HashMap::new());
+}
+
+pub fn with_write<F, R>(key: &str, f: F) -> R
+where
+    F: FnOnce(&mut ScoreSet) -> R,
+{
+    SETS.with(|cell| {
+        let mut map = cell.borrow_mut();
+        let result;
+        {
+            let set = map.entry(key.to_owned()).or_default();
+            result = f(set);
+            if set.is_empty() {
+                map.remove(key);
+            }
+        }
+        result
+    })
+}
+
+pub fn with_read<F, R>(key: &str, f: F) -> R
+where
+    F: FnOnce(&ScoreSet) -> R,
+{
+    SETS.with(|cell| {
+        let map = cell.borrow();
+        f(map.get(key).unwrap_or(&ScoreSet::default()))
+    })
+}


### PR DESCRIPTION
## Summary
- remove the dashmap concurrency layer
- introduce a thread-local `RefCell<HashMap>` with helper accessors
- refactor commands to use the new API
- update documentation for the single-threaded design

## Testing
- `cargo build --all-targets`
- `cargo test --all --all-targets -- --test-threads=1`
- `cargo clippy --all-targets -- -D warnings -W clippy::uninlined_format_args`


------
https://chatgpt.com/codex/tasks/task_e_686eeace0b008326aa1b0673fe13ed9c