### PR TITLE
Improve pop performance and add benchmarks

### DIFF
--- a/.github/scripts/check_pop.py
+++ b/.github/scripts/check_pop.py
@@ -1,0 +1,17 @@
+import json, sys
+from pathlib import Path
+
+base = Path('target/criterion/pop_loop_vs_baseline/base/estimates.json')
+new = Path('target/criterion/pop_loop_vs_baseline/new/estimates.json')
+with base.open() as f:
+    b = json.load(f)
+with new.open() as f:
+    n = json.load(f)
+base_mean = b['mean']['point_estimate']
+new_mean = n['mean']['point_estimate']
+if base_mean == 0:
+    raise SystemExit('invalid baseline')
+impr = (base_mean - new_mean) / base_mean
+print(f"Improvement: {impr*100:.1f}%")
+if impr < 0.10:
+    raise SystemExit('pop loop speedup <10%')

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,19 @@
+name: Bench
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master, main ]
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Bench
+        run: cargo bench --all --features bench

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,12 @@ jobs:
         run: cargo fmt -- --check
         shell: bash
       - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings -D clippy::to_string_in_format_args
+        shell: bash
+      - name: Check HashMap usage
+        run: |
+          RG=$(rg --count '#\\[cfg(test\\)]?\\s*use std::collections::HashMap' -g '!**/target/**')
+          test "$RG" -eq 0
         shell: bash
       - name: Check duplicates
         run: cargo tree -d
@@ -39,3 +44,12 @@ jobs:
       - name: Test
         run: cargo test --all --all-targets --verbose
         shell: bash
+      - name: Bench baseline
+        run: |
+          git checkout HEAD~1
+          cargo bench --features bench --bench gzpop -- --save-baseline base
+          git checkout -
+      - name: Bench current
+        run: cargo bench --features bench --bench gzpop -- --baseline base --save-baseline new
+      - name: Check bench improvement
+        run: python .github/scripts/check_pop.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,6 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings -D clippy::to_string_in_format_args
         shell: bash
-      - name: Check HashMap usage
-        run: |
-          RG=$(rg --count '#\\[cfg(test\\)]?\\s*use std::collections::HashMap' -g '!**/target/**')
-          test "$RG" -eq 0
-        shell: bash
       - name: Check duplicates
         run: cargo tree -d
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,10 +145,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -167,6 +185,33 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clang-sys"
@@ -234,6 +279,73 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits 0.2.19",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "displaydoc"
@@ -321,6 +433,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "criterion",
  "heck 0.5.0",
  "once_cell",
  "ordered-float",
@@ -329,7 +442,19 @@ dependencies = [
  "rand",
  "redis",
  "redis-module",
+ "rustc-hash",
+ "ryu",
  "which",
+]
+
+[[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -343,6 +468,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "home"
@@ -461,16 +592,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -631,6 +792,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +823,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits 0.2.19",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portpicker"
@@ -757,6 +952,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -876,6 +1091,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,6 +1117,18 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.40",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1012,6 +1248,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,10 +1293,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote 1.0.40",
+ "syn 2.0.104",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote 1.0.40",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.40",
+ "syn 2.0.104",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "which"
@@ -1062,6 +1386,15 @@ dependencies = [
  "home",
  "once_cell",
  "rustix",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,23 @@ crate-type = ["cdylib", "rlib"]
 name = "xtask"
 path = "src/bin/xtask.rs"
 
+[[bench]]
+name = "gzpop"
+harness = false
+required-features = ["bench"]
+
+[[bench]]
+name = "format"
+harness = false
+required-features = ["bench"]
+
 [dependencies]
 redis-module = "2.0.7"
 once_cell = "1"
 ordered-float = "2"
 anyhow = "1"
+ryu = "1"
+rustc-hash = "1"
 clap = { version = "4", features = ["derive"] }
 portpicker = "0.1"
 redis = "0.25"
@@ -26,4 +38,8 @@ rand = "0.8"
 [dev-dependencies]
 quickcheck = "1"
 which = "4"
+criterion = "0.5"
+
+[features]
+bench = []
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # gzset – B‑tree Sorted‑Set Module for Valkey/Redis  
 ![CI](https://github.com/<your‑org>/gzset/actions/workflows/ci.yml/badge.svg)
+![Bench](https://github.com/<your-org>/gzset/actions/workflows/bench.yml/badge.svg)
 
 **gzset** is an experimental Valkey/Redis module that re‑implements
 `ZSET` semantics on top of an **in‑memory B‑tree** rather than the

--- a/benches/format.rs
+++ b/benches/format.rs
@@ -1,0 +1,24 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use gzset::fmt_f64;
+
+fn bench_format(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fmt_vs_to_string");
+    group.bench_function("fmt_f64", |b| {
+        b.iter(|| {
+            for _ in 0..1_000_000 {
+                black_box(fmt_f64(black_box(42.123456)));
+            }
+        })
+    });
+    group.bench_function("to_string", |b| {
+        b.iter(|| {
+            for _ in 0..1_000_000 {
+                black_box(black_box(42.123456).to_string());
+            }
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_format);
+criterion_main!(benches);

--- a/benches/gzpop.rs
+++ b/benches/gzpop.rs
@@ -1,0 +1,29 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use gzset::ScoreSet;
+
+fn bench_pop(c: &mut Criterion) {
+    let entries: Vec<(f64, String)> = (0..1_000_000).map(|i| (i as f64, i.to_string())).collect();
+    let mut group = c.benchmark_group("pop_loop_vs_baseline");
+    group.bench_function("pop_min", |b| {
+        b.iter(|| {
+            let mut set = ScoreSet::default();
+            for (s, m) in &entries {
+                set.insert(*s, m);
+            }
+            set.pop_all(true);
+        })
+    });
+    group.bench_function("pop_max", |b| {
+        b.iter(|| {
+            let mut set = ScoreSet::default();
+            for (s, m) in &entries {
+                set.insert(*s, m);
+            }
+            set.pop_all(false);
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_pop);
+criterion_main!(benches);

--- a/src/sets.rs
+++ b/src/sets.rs
@@ -1,10 +1,10 @@
+use crate::FastHashMap;
 use std::cell::RefCell;
-use std::collections::HashMap;
 
 use crate::ScoreSet;
 
 thread_local! {
-    static SETS: RefCell<HashMap<String, ScoreSet>> = RefCell::new(HashMap::new());
+    static SETS: RefCell<FastHashMap<String, ScoreSet>> = RefCell::new(FastHashMap::default());
 }
 
 pub fn with_write<F, R>(key: &str, f: F) -> R

--- a/tests/zset.rs
+++ b/tests/zset.rs
@@ -2307,13 +2307,13 @@ fn zrandmember_basics() {
 /* ZRANDMEMBER WITHSCORES */
 #[test]
 fn zrandmember_withscores() {
-    use std::collections::HashMap;
+    use gzset::FastHashMap as HashMap;
     with_families(|ctx| {
         ctx.del("zkey");
         ctx.add("zkey", 1.0, "a").unwrap();
         ctx.add("zkey", 2.0, "b").unwrap();
         let vals = ctx.randmember("zkey", Some(2), true).unwrap();
-        let mut map = HashMap::new();
+        let mut map = HashMap::default();
         for pair in vals.chunks(2) {
             map.insert(pair[0].clone(), pair[1].clone());
         }


### PR DESCRIPTION
## Summary
- add public float formatter using ryu and expose FastHashMap
- provide `ScoreSet::pop_all` for bench builds
- benchmark pop loops and f64 formatting
- enforce clippy rule against `to_string` in format args
- add CI step to ensure pop benchmark is faster than previous commit

## Testing
- `cargo fmt -- --check`
- `cargo clippy --all-targets --features bench -- -D warnings -W clippy::uninlined_format_args -D clippy::to_string_in_format_args`
- `cargo build --all-targets --features bench`
- `cargo test --all --all-targets --features bench`


------
https://chatgpt.com/codex/tasks/task_e_687022a585748326a5b176bb0b1352f1