### PR TITLE
Use SmallVec buckets for per-score storage

### DIFF
--- a/src/score_set.rs
+++ b/src/score_set.rs
@@ -1,30 +1,29 @@
 use ordered_float::OrderedFloat;
-use std::collections::{BTreeMap, BTreeSet};
+use smallvec::SmallVec;
+use std::collections::BTreeMap;
 
 use crate::{
     pool::{MemberId, StringPool},
     FastHashMap,
 };
 
+type Bucket = SmallVec<[MemberId; 4]>;
+
 #[derive(Default)]
 pub struct ScoreSet {
-    pub(crate) by_score: BTreeMap<OrderedFloat<f64>, BTreeSet<&'static str>>,
+    pub(crate) by_score: BTreeMap<OrderedFloat<f64>, Bucket>,
     pub(crate) members: FastHashMap<MemberId, OrderedFloat<f64>>,
     pub(crate) pool: StringPool,
 }
 
 #[derive(Clone, Debug)]
 pub struct ScoreIter<'a> {
-    front_outer: std::collections::btree_map::Iter<'a, OrderedFloat<f64>, BTreeSet<&'static str>>,
-    front_current: Option<(
-        std::collections::btree_set::Iter<'a, &'static str>,
-        OrderedFloat<f64>,
-    )>,
-    back_outer: std::iter::Rev<
-        std::collections::btree_map::Iter<'a, OrderedFloat<f64>, BTreeSet<&'static str>>,
-    >,
+    pool: &'a StringPool,
+    front_outer: std::collections::btree_map::Iter<'a, OrderedFloat<f64>, Bucket>,
+    front_current: Option<(std::slice::Iter<'a, MemberId>, OrderedFloat<f64>)>,
+    back_outer: std::iter::Rev<std::collections::btree_map::Iter<'a, OrderedFloat<f64>, Bucket>>,
     back_current: Option<(
-        std::collections::btree_set::Iter<'a, &'static str>,
+        std::iter::Rev<std::slice::Iter<'a, MemberId>>,
         OrderedFloat<f64>,
     )>,
     remaining_front_skip: usize,
@@ -36,12 +35,14 @@ pub struct ScoreIter<'a> {
 
 impl<'a> ScoreIter<'a> {
     fn new(
-        map: &'a BTreeMap<OrderedFloat<f64>, BTreeSet<&'static str>>,
+        map: &'a BTreeMap<OrderedFloat<f64>, Bucket>,
+        pool: &'a StringPool,
         start: usize,
         stop: usize,
         len: usize,
     ) -> Self {
         Self {
+            pool,
             front_outer: map.iter(),
             front_current: None,
             back_outer: map.iter().rev(),
@@ -54,8 +55,9 @@ impl<'a> ScoreIter<'a> {
         }
     }
 
-    fn empty(map: &'a BTreeMap<OrderedFloat<f64>, BTreeSet<&'static str>>) -> Self {
+    fn empty(map: &'a BTreeMap<OrderedFloat<f64>, Bucket>, pool: &'a StringPool) -> Self {
         Self {
+            pool,
             front_outer: map.iter(),
             front_current: None,
             back_outer: map.iter().rev(),
@@ -83,19 +85,20 @@ impl<'a> Iterator for ScoreIter<'a> {
         }
         loop {
             if let Some((ref mut iter, score)) = self.front_current {
-                for member in iter.by_ref() {
+                for id in iter.by_ref() {
                     if self.remaining_front_skip > 0 {
                         self.remaining_front_skip -= 1;
                         continue;
                     }
                     self.yielded_front += 1;
-                    return Some((*member, score.0));
+                    let member = self.pool.get(*id);
+                    return Some((member, score.0));
                 }
                 self.front_current = None;
             }
             match self.front_outer.next() {
-                Some((score, set)) => {
-                    self.front_current = Some((set.iter(), *score));
+                Some((score, bucket)) => {
+                    self.front_current = Some((bucket.iter(), *score));
                 }
                 None => return None,
             }
@@ -115,19 +118,20 @@ impl<'a> DoubleEndedIterator for ScoreIter<'a> {
         }
         loop {
             if let Some((ref mut iter, score)) = self.back_current {
-                for member in iter.by_ref().rev() {
+                for id in iter.by_ref() {
                     if self.remaining_back_skip > 0 {
                         self.remaining_back_skip -= 1;
                         continue;
                     }
                     self.yielded_back += 1;
-                    return Some((*member, score.0));
+                    let member = self.pool.get(*id);
+                    return Some((member, score.0));
                 }
                 self.back_current = None;
             }
             match self.back_outer.next() {
-                Some((score, set)) => {
-                    self.back_current = Some((set.iter(), *score));
+                Some((score, bucket)) => {
+                    self.back_current = Some((bucket.iter().rev(), *score));
                 }
                 None => return None,
             }
@@ -145,21 +149,31 @@ impl ScoreSet {
     pub fn insert(&mut self, score: f64, member: &str) -> bool {
         let key = OrderedFloat(score);
         let id = self.pool.intern(member);
-        let name = self.pool.get_static(id);
+        let name = self.pool.get(id);
         match self.members.insert(id, key) {
             Some(old) if old == key => return false,
             Some(old) => {
-                if let Some(set) = self.by_score.get_mut(&old) {
-                    set.remove(name);
-                    if set.is_empty() {
+                if let Some(bucket) = self.by_score.get_mut(&old) {
+                    if let Ok(pos) = bucket.binary_search_by(|&m| self.pool.get(m).cmp(name)) {
+                        bucket.remove(pos);
+                    }
+                    if bucket.is_empty() {
                         self.by_score.remove(&old);
+                    } else if bucket.spilled() && bucket.len() <= 4 {
+                        bucket.shrink_to_fit();
                     }
                 }
             }
             None => {}
         }
-        self.by_score.entry(key).or_default().insert(name);
-        true
+        let bucket = self.by_score.entry(key).or_default();
+        match bucket.binary_search_by(|&m| self.pool.get(m).cmp(name)) {
+            Ok(_) => false,
+            Err(pos) => {
+                bucket.insert(pos, id);
+                true
+            }
+        }
     }
 
     pub fn remove(&mut self, member: &str) -> bool {
@@ -168,10 +182,14 @@ impl ScoreSet {
             None => return false,
         };
         if let Some(score) = self.members.remove(&id) {
-            if let Some(set) = self.by_score.get_mut(&score) {
-                set.remove(member);
-                if set.is_empty() {
+            if let Some(bucket) = self.by_score.get_mut(&score) {
+                if let Ok(pos) = bucket.binary_search_by(|&m| self.pool.get(m).cmp(member)) {
+                    bucket.remove(pos);
+                }
+                if bucket.is_empty() {
                     self.by_score.remove(&score);
+                } else if bucket.spilled() && bucket.len() <= 4 {
+                    bucket.shrink_to_fit();
                 }
             }
             true
@@ -188,18 +206,17 @@ impl ScoreSet {
     pub fn rank(&self, member: &str) -> Option<usize> {
         let id = self.pool.lookup(member)?;
         let target = *self.members.get(&id)?;
-        let name = self.pool.get(id);
         let mut idx = 0usize;
-        for (score, set) in &self.by_score {
+        for (score, bucket) in &self.by_score {
             if *score == target {
-                for m in set {
-                    if *m == name {
+                for m in bucket {
+                    if *m == id {
                         return Some(idx);
                     }
                     idx += 1;
                 }
             } else {
-                idx += set.len();
+                idx += bucket.len();
             }
         }
         None
@@ -208,7 +225,7 @@ impl ScoreSet {
     pub fn iter_range(&self, start: isize, stop: isize) -> ScoreIter<'_> {
         let len = self.members.len() as isize;
         if len == 0 {
-            return ScoreIter::empty(&self.by_score);
+            return ScoreIter::empty(&self.by_score, &self.pool);
         }
         let mut start = if start < 0 { len + start } else { start };
         let mut stop = if stop < 0 { len + stop } else { stop };
@@ -216,15 +233,21 @@ impl ScoreSet {
             start = 0;
         }
         if stop < 0 {
-            return ScoreIter::empty(&self.by_score);
+            return ScoreIter::empty(&self.by_score, &self.pool);
         }
         if stop >= len {
             stop = len - 1;
         }
         if start > stop {
-            return ScoreIter::empty(&self.by_score);
+            return ScoreIter::empty(&self.by_score, &self.pool);
         }
-        ScoreIter::new(&self.by_score, start as usize, stop as usize, len as usize)
+        ScoreIter::new(
+            &self.by_score,
+            &self.pool,
+            start as usize,
+            stop as usize,
+            len as usize,
+        )
     }
 
     pub fn range_iter(&self, start: isize, stop: isize) -> Vec<(f64, String)> {
@@ -243,9 +266,9 @@ impl ScoreSet {
 
     pub fn all_items(&self) -> Vec<(f64, String)> {
         let mut out = Vec::new();
-        for (score, set) in &self.by_score {
-            for m in set {
-                out.push((score.0, (*m).to_owned()));
+        for (score, bucket) in &self.by_score {
+            for id in bucket {
+                out.push((score.0, self.pool.get(*id).to_owned()));
             }
         }
         out
@@ -271,6 +294,13 @@ impl ScoreSet {
             .is_some_and(|id| self.members.contains_key(&id))
     }
 
+    #[doc(hidden)]
+    pub fn bucket_capacity_for_test(&self, score: f64) -> Option<usize> {
+        self.by_score
+            .get(&OrderedFloat(score))
+            .map(|b| b.capacity())
+    }
+
     #[cfg(any(test, feature = "bench"))]
     pub fn pop_all(&mut self, min: bool) -> Vec<String> {
         let mut out = Vec::new();
@@ -280,21 +310,19 @@ impl ScoreSet {
             } else {
                 self.by_score.last_entry().unwrap()
             };
-            let set = entry.get_mut();
-            let member = if min {
-                let m = *set.iter().next().unwrap();
-                set.take(m).unwrap()
+            let bucket = entry.get_mut();
+            let id = if min {
+                bucket.remove(0)
             } else {
-                let m = *set.iter().next_back().unwrap();
-                set.take(m).unwrap()
+                bucket.pop().unwrap()
             };
-            let empty = set.is_empty();
-            if empty {
+            if bucket.is_empty() {
                 entry.remove_entry();
+            } else if bucket.spilled() && bucket.len() <= 4 {
+                bucket.shrink_to_fit();
             }
-            let id = self.pool.lookup(member).unwrap();
             self.members.remove(&id);
-            out.push(member.to_owned());
+            out.push(self.pool.get(id).to_owned());
         }
         out
     }

--- a/tests/score_set.rs
+++ b/tests/score_set.rs
@@ -46,3 +46,33 @@ fn pop_min_max_duplicates() {
     }
     assert_eq!(maxs, ["c", "b", "a"]);
 }
+
+#[test]
+fn insertion_order_five_members() {
+    let mut set = ScoreSet::default();
+    for m in ["e", "d", "c", "b", "a"] {
+        set.insert(1.0, m);
+    }
+    let items: Vec<_> = set.range_iter(0, -1);
+    let members: Vec<_> = items.into_iter().map(|(_, m)| m).collect();
+    assert_eq!(members, ["a", "b", "c", "d", "e"]);
+}
+
+#[test]
+fn duplicate_reject() {
+    let mut set = ScoreSet::default();
+    assert!(set.insert(1.0, "a"));
+    assert!(!set.insert(1.0, "a"));
+}
+
+#[test]
+fn grow_and_shrink_bucket() {
+    let mut set = ScoreSet::default();
+    for m in ["a", "b", "c", "d", "e"] {
+        set.insert(1.0, m);
+    }
+    assert!(set.bucket_capacity_for_test(1.0).is_some_and(|c| c > 4));
+    set.remove("a");
+    set.remove("b");
+    assert_eq!(set.bucket_capacity_for_test(1.0), Some(4));
+}


### PR DESCRIPTION
## Summary
- store per-score members in SmallVec buckets and maintain lexicographic order
- update memory accounting for inline vs spilled buckets
- add tests for insertion order, duplicate handling, and bucket shrinking

## Testing
- `cargo fmt -- --check`
- `cargo build --all-targets`
- `cargo clippy --all-targets -- -D warnings -W clippy::uninlined_format_args`
- `cargo test --all --verbose`


------
https://chatgpt.com/codex/tasks/task_e_689136ff66248326818bd41c23201d24