### PR TITLE
Reject non-finite scores in gzadd

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -125,6 +125,9 @@ fn gzadd(_ctx: &Context, args: Vec<RedisString>) -> Result {
     }
     let key = args[1].try_as_str()?;
     let score: f64 = args[2].parse_float()?;
+    if !score.is_finite() {
+        return Err(RedisError::Str("ERR score is not a finite number"));
+    }
     let member = args[3].try_as_str()?;
 
     let added = with_set_write(_ctx, key, |s| s.insert(score, member))?;

--- a/src/format.rs
+++ b/src/format.rs
@@ -3,6 +3,7 @@ use std::cell::RefCell;
 
 #[inline]
 pub fn fmt_f64(buf: &mut Buffer, score: f64) -> &str {
+    debug_assert!(score.is_finite());
     let formatted = buf.format_finite(score);
     formatted.strip_suffix(".0").unwrap_or(formatted)
 }

--- a/tests/gzadd_non_finite.rs
+++ b/tests/gzadd_non_finite.rs
@@ -1,0 +1,22 @@
+mod helpers;
+
+#[test]
+fn gzadd_rejects_non_finite() -> redis::RedisResult<()> {
+    let vk = helpers::ValkeyInstance::start();
+    let mut con = redis::Client::open(vk.url())?.get_connection()?;
+    for val in ["nan", "inf", "-inf"] {
+        let res: redis::RedisResult<()> = redis::cmd("GZADD")
+            .arg("s")
+            .arg(val)
+            .arg("m")
+            .query(&mut con);
+        assert!(res.is_err());
+        let err = res.unwrap_err();
+        if val == "nan" {
+            assert!(err.to_string().contains("parse as float"));
+        } else {
+            assert!(err.to_string().contains("score is not a finite number"));
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- validate GZADD score is finite and return an error otherwise
- assert scores are finite before formatting
- test rejection of nan/inf inputs

## Testing
- `cargo fmt -- --check`
- `cargo build --all-targets`
- `cargo clippy --all-targets -- -D warnings -W clippy::uninlined_format_args`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c08efe7a748326a51cabd758cf8ba7