### PR TITLE
Stream iterators for score set

### DIFF
--- a/src/compact_table.rs
+++ b/src/compact_table.rs
@@ -62,6 +62,7 @@ impl CompactTable {
     }
 
     #[inline]
+    #[allow(dead_code)]
     pub fn iter(&self) -> impl Iterator<Item = (MemberId, f64)> + '_ {
         // SAFETY: all elements in the table are initialized
         unsafe { self.table.iter() }.map(|bucket| {


### PR DESCRIPTION
## Summary
- add zero-clone iter_all and iter_from to ScoreSet
- stream set data in union/inter/diff/scan/randmember
- gate eager helper methods for tests and benches

## Testing
- `cargo fmt -- --check`
- `cargo build --all-targets`
- `cargo clippy --all-targets -- -D warnings -W clippy::uninlined_format_args`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c3372262d483269763ef3d87e44ef2