### PR TITLE
Avoid full materialization in GZRANDMEMBER

### DIFF
--- a/src/score_set.rs
+++ b/src/score_set.rs
@@ -280,6 +280,17 @@ impl ScoreSet {
         None
     }
 
+    pub fn select_by_rank(&self, mut r: usize) -> (&str, f64) {
+        for (score, bucket) in &self.by_score {
+            if r < bucket.len() {
+                let id = bucket[r];
+                return (self.pool.get(id), score.0);
+            }
+            r -= bucket.len();
+        }
+        unreachable!("rank out of bounds");
+    }
+
     pub fn iter_range(&self, start: isize, stop: isize) -> ScoreIter<'_> {
         let len = self.members.len() as isize;
         if len == 0 {

--- a/tests/gzrandmember.rs
+++ b/tests/gzrandmember.rs
@@ -1,0 +1,39 @@
+mod helpers;
+
+use std::collections::HashSet;
+
+#[test]
+fn gzrandmember_samples() -> redis::RedisResult<()> {
+    let vk = helpers::ValkeyInstance::start();
+    let mut con = redis::Client::open(vk.url())?.get_connection()?;
+
+    for i in 0..100 {
+        redis::cmd("GZADD")
+            .arg("s")
+            .arg(i)
+            .arg(format!("m{i}"))
+            .execute(&mut con);
+    }
+
+    // single random member
+    let single: String = redis::cmd("GZRANDMEMBER").arg("s").query(&mut con)?;
+    assert!(single.starts_with('m'));
+
+    // multiple distinct members
+    let items: Vec<String> = redis::cmd("GZRANDMEMBER").arg("s").arg(5).query(&mut con)?;
+    assert_eq!(items.len(), 5);
+    let set: HashSet<_> = items.iter().cloned().collect();
+    assert_eq!(set.len(), 5);
+
+    // allow duplicates
+    let dup_items: Vec<String> = redis::cmd("GZRANDMEMBER")
+        .arg("s")
+        .arg(-5)
+        .query(&mut con)?;
+    assert_eq!(dup_items.len(), 5);
+    for item in dup_items {
+        assert!(item.starts_with('m'));
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add ScoreSet::select_by_rank to retrieve members by rank without scanning the whole set
- sample ranks directly in GZRANDMEMBER to avoid allocating large vectors for small counts
- test random sampling behavior of GZRANDMEMBER

## Testing
- `cargo build --all-targets`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings -W clippy::uninlined_format_args`


------
https://chatgpt.com/codex/tasks/task_e_68c4667092e4832692aee0280269fc57