### PR TITLE
Use ahash by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.3",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -430,7 +431,19 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.5+wasi-0.2.4",
 ]
 
 [[package]]
@@ -449,6 +462,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 name = "gzset"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "clap",
  "criterion",
@@ -955,6 +969,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,7 +1001,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1345,6 +1365,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.5+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.0+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1587,6 +1625,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ anyhow = "1"
 ryu = "1"
 rustc-hash = "1"
 hashbrown = { version = "0.14", features = ["raw"] }
+ahash = "0.8"
 clap = { version = "4", features = ["derive"] }
 portpicker = "0.1"
 redis = "0.25"
@@ -51,4 +52,5 @@ criterion = "0.5"
 bench = []
 mem_profile = []
 redis-module = []
+fast-hash = []
 

--- a/src/compact_table.rs
+++ b/src/compact_table.rs
@@ -6,6 +6,7 @@
 // according to those terms.
 
 use hashbrown::raw::RawTable;
+// MemberId is an internal u32 index; using FxHasher here is safe and fast.
 use rustc_hash::FxHasher;
 use std::hash::{BuildHasher, BuildHasherDefault};
 
@@ -28,6 +29,7 @@ impl CompactTable {
 
     #[inline]
     fn hash(id: MemberId) -> u64 {
+        // MemberId is not attacker-controlled; FxHasher is acceptable.
         BuildFxHasher::default().hash_one(id)
     }
 

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,8 +1,18 @@
+#[cfg(not(feature = "fast-hash"))]
+use ahash::AHashMap;
+#[cfg(feature = "fast-hash")]
 use hashbrown::HashMap;
+#[cfg(feature = "fast-hash")]
 use rustc_hash::FxHasher;
+#[cfg(feature = "fast-hash")]
 use std::hash::BuildHasherDefault;
 
+#[cfg(feature = "fast-hash")]
+/// FxHasher-based map used only when the `fast-hash` feature is enabled.
 pub type FastHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
+#[cfg(not(feature = "fast-hash"))]
+/// Default to `AHashMap` for DOS-resistant hashing of user-provided names.
+pub type FastHashMap<K, V> = AHashMap<K, V>;
 pub type MemberId = u32;
 
 #[derive(Default, Debug)]


### PR DESCRIPTION
## Summary
- add `ahash` dependency and `fast-hash` feature
- default `FastHashMap` to DOS-resistant `AHashMap`; keep `FxHasher` behind feature flag
- document `FxHasher` use for internal `MemberId`

## Testing
- `cargo fmt -- --check`
- `cargo build --all-targets`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings -W clippy::uninlined_format_args`


------
https://chatgpt.com/codex/tasks/task_e_68c4845b0a488326adae79d32f50b394