### PR TITLE
Enable Valkey allocator for cargo valkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Each `GZSET` key owns its B-tree data directly, so `MEMORY USAGE` reflects the e
 cargo build -p gzset
 
 # 2. Launch a throw‑away Valkey instance with the module pre‑loaded
+# (builds the module with the `redis-module` feature so memory stats are accurate)
 cargo valkey -- --loglevel warning
 #                       └─────────────── extra args passed straight to valkey-server
 

--- a/src/bin/xtask.rs
+++ b/src/bin/xtask.rs
@@ -102,6 +102,8 @@ fn start_valkey(
     if matches!(profile, Profile::Release) {
         build.arg("--release");
     }
+    // Use Valkey's allocator by default so MEMORY USAGE & maxmemory behave correctly.
+    build.arg("--features").arg("redis-module");
     anyhow::ensure!(build.status()?.success(), "cargo build failed");
 
     // 2) Resolve full path to the .so/.dylib/.dll ----------------------------


### PR DESCRIPTION
## Summary
- build `cargo valkey` with the `redis-module` feature for accurate memory statistics
- document that `cargo valkey` enables the Valkey allocator by default

## Testing
- `cargo fmt -- --check`
- `cargo build --all-targets`
- `cargo clippy --all-targets -- -D warnings -W clippy::uninlined_format_args`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c48dad22c483268b38edccffe33afc