### PR TITLE
Wire up bench gating with baselines and checker

### DIFF
--- a/.github/scripts/check_pop.py
+++ b/.github/scripts/check_pop.py
@@ -3,8 +3,11 @@ import json, sys, glob
 GROUP = "pop_loop_vs_baseline"
 
 def read_mean(path):
-    with open(path) as f:
-        return json.load(f)["mean"]["point_estimate"]
+    try:
+        with open(path) as f:
+            return json.load(f)["mean"]["point_estimate"]
+    except json.JSONDecodeError as e:
+        sys.exit(f"[bench] invalid JSON in {path}: {e}")
 
 def sum_means(baseline):
     # Works whether Criterion organizes as group/function/baseline or group/baseline

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -30,7 +30,7 @@ jobs:
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           HEAD_SHA="${{ github.sha }}"
           git checkout "$BASE_SHA"
-          cargo bench -p gzset --bench gzpop --features bench -- --quiet --sample-size 10 --save-baseline base
+          cargo bench -p gzset --bench gzpop --features bench -- --quiet --noplot --sample-size 10 --save-baseline base
           git checkout "$HEAD_SHA"
 
       - name: Save baseline (base) — push
@@ -39,11 +39,11 @@ jobs:
           BASE_SHA="$(git rev-parse HEAD^)"
           HEAD_SHA="${{ github.sha }}"
           git checkout "$BASE_SHA"
-          cargo bench -p gzset --bench gzpop --features bench -- --quiet --sample-size 10 --save-baseline base
+          cargo bench -p gzset --bench gzpop --features bench -- --quiet --noplot --sample-size 10 --save-baseline base
           git checkout "$HEAD_SHA"
 
       - name: Run current benches (new)
-        run: cargo bench -p gzset --bench gzpop --features bench -- --quiet --sample-size 10 --save-baseline new
+        run: cargo bench -p gzset --bench gzpop --features bench -- --quiet --noplot --sample-size 10 --save-baseline new
 
       - name: Enforce pop-loop speedup
         run: python3 .github/scripts/check_pop.py


### PR DESCRIPTION
## Summary
- compare benches against PR base or previous commit and enforce a pop loop speedup
- aggregate Criterion baselines and ensure at least 10% improvement

## Testing
- `cargo build --all-targets`
- `cargo test`
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings -W clippy::uninlined_format_args`


------
https://chatgpt.com/codex/tasks/task_e_68c48e8be70c83268874d0101f756ddd