### PR TITLE
Align Clippy flags across docs and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: cargo fmt -- --check
         shell: bash
       - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings -D clippy::to_string_in_format_args
+        run: cargo clippy --all-targets -- -D warnings -D clippy::to_string_in_format_args -D clippy::uninlined_format_args
         shell: bash
       - name: Check duplicates
         run: cargo tree -d

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,11 @@ cargo fmt -- --check
 Code must pass Clippy without warnings:
 
 ```bash
-cargo clippy --all-targets -- -D warnings -W clippy::uninlined_format_args
+cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args
 ```
 - Avoid `format!("foo{}", x)`; use `format!("foo{x}")` to satisfy `clippy::uninlined_format_args`.
+
+- Avoid `.to_string()` inside `format!` macros; use values directly to satisfy `clippy::to_string_in_format_args`.
 
 ## No unchecked files
 - Ensure `git status --porcelain` shows no changes.


### PR DESCRIPTION
## Summary
- add `clippy::uninlined_format_args` to CI clippy step
- document clippy flags used in CI

## Testing
- `cargo build --all-targets`
- `cargo test`
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args`


------
https://chatgpt.com/codex/tasks/task_e_68c490d4169083268ce82314568a983b