### PR TITLE
Clarify string reclamation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ Each set lives as a Valkey key holding a `ScoreSet` value. Commands open the
 key directly and operate on its data; no global map or flush handler is needed.
 Valkey handles key eviction and expiry automatically.
 
-> **Note:** member strings are interned in a per‑set pool and are not
-> reclaimed when removed. Long‑lived sets that churn will retain the old
-> strings until the entire set is dropped.
+> **Note:** member strings are interned in a per‑set pool. When a member is
+> removed, its `Box<str>` is dropped and the ID is reused; the vector that
+> stores IDs may retain capacity (amortized), but string memory itself is reclaimed.
 Future work will:
 
 1. Add RDB/AOF serialization hooks.


### PR DESCRIPTION
## Summary
- Clarify that removed members' strings are dropped and IDs reused in per-set pools

## Testing
- `cargo fmt -- --check`
- `cargo build --all-targets`
- `cargo clippy --all-targets -- -D warnings -W clippy::uninlined_format_args`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c490d724e08326b13a472b49c5c4fa