### PR TITLE
Fail CI on duplicate dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings -D clippy::to_string_in_format_args
         shell: bash
       - name: Check duplicates
-        run: cargo tree -d
+        run: |
+          OUT="$(cargo tree -d)"
+          echo "$OUT"
+          test -z "$OUT" || { echo "::error::duplicate dependencies detected"; exit 1; }
         shell: bash
       - name: Test
         run: cargo test --all --all-targets --verbose


### PR DESCRIPTION
## Summary
- ensure CI fails when cargo tree detects duplicate dependencies

## Testing
- `cargo fmt -- --check`
- `cargo build --all-targets`
- `cargo clippy --all-targets -- -D warnings -W clippy::uninlined_format_args`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c490e2fb388326a0a4455e9be6d835