### PR TITLE
Avoid double allocation in string pool

### DIFF
--- a/src/score_set.rs
+++ b/src/score_set.rs
@@ -267,7 +267,7 @@ impl ScoreSet {
             self.mem_breakdown.member_table += new_table - prev_table;
         }
         if is_new {
-            let bytes = member.len() * 2;
+            let bytes = member.len();
             self.mem_bytes += bytes;
             #[cfg(test)]
             {
@@ -378,7 +378,7 @@ impl ScoreSet {
                 }
             }
             if self.pool.remove(member).is_some() {
-                let bytes = member.len() * 2;
+                let bytes = member.len();
                 self.mem_bytes -= bytes;
                 #[cfg(test)]
                 {
@@ -600,7 +600,7 @@ impl ScoreSet {
             }
             let name = self.pool.get(id).to_owned();
             if self.pool.remove(&name).is_some() {
-                let bytes = name.len() * 2;
+                let bytes = name.len();
                 self.mem_bytes -= bytes;
                 #[cfg(test)]
                 {


### PR DESCRIPTION
## Summary
- refactor `StringPool` to store non-owning pointers to map-owned strings and remove redundant boxed clones
- update `ScoreSet` string memory accounting to match the single-allocation pool semantics

## Testing
- cargo build --all-targets
- cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68c8594e75088326b527d9e123578fa4