### PR TITLE
Deduplicate string pool storage

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -6,6 +6,7 @@ use hashbrown::HashMap;
 use rustc_hash::FxHasher;
 #[cfg(feature = "fast-hash")]
 use std::hash::BuildHasherDefault;
+use std::ptr::NonNull;
 
 #[cfg(feature = "fast-hash")]
 /// FxHasher-based map used only when the `fast-hash` feature is enabled.
@@ -18,7 +19,7 @@ pub type MemberId = u32;
 #[derive(Default, Debug)]
 pub struct StringPool {
     pub(crate) map: FastHashMap<Box<str>, MemberId>,
-    pub(crate) strings: Vec<Option<Box<str>>>,
+    pub(crate) strings: Vec<Option<NonNull<str>>>,
     pub(crate) free_ids: Vec<MemberId>,
 }
 
@@ -28,12 +29,13 @@ impl StringPool {
             id
         } else {
             let boxed: Box<str> = s.to_owned().into_boxed_str();
+            let ptr = NonNull::from(boxed.as_ref());
             let id = if let Some(id) = self.free_ids.pop() {
-                self.strings[id as usize] = Some(boxed.clone());
+                self.strings[id as usize] = Some(ptr);
                 id
             } else {
                 let id = self.strings.len() as MemberId;
-                self.strings.push(Some(boxed.clone()));
+                self.strings.push(Some(ptr));
                 id
             };
             self.map.insert(boxed, id);
@@ -46,9 +48,14 @@ impl StringPool {
     }
 
     pub fn get(&self, id: MemberId) -> &str {
-        self.strings[id as usize]
-            .as_deref()
-            .expect("invalid member id")
+        // SAFETY: `self.strings` stores pointers to allocations owned by `self.map`.
+        // Entries are cleared when removed, so dereferencing here is valid for live IDs.
+        unsafe {
+            self.strings[id as usize]
+                .as_ref()
+                .expect("invalid member id")
+                .as_ref()
+        }
     }
 
     pub fn remove(&mut self, s: &str) -> Option<MemberId> {

--- a/src/score_set.rs
+++ b/src/score_set.rs
@@ -267,7 +267,7 @@ impl ScoreSet {
             self.mem_breakdown.member_table += new_table - prev_table;
         }
         if is_new {
-            let bytes = member.len() * 2;
+            let bytes = member.len();
             self.mem_bytes += bytes;
             #[cfg(test)]
             {
@@ -378,7 +378,7 @@ impl ScoreSet {
                 }
             }
             if self.pool.remove(member).is_some() {
-                let bytes = member.len() * 2;
+                let bytes = member.len();
                 self.mem_bytes -= bytes;
                 #[cfg(test)]
                 {
@@ -605,7 +605,7 @@ impl ScoreSet {
 
         let name = self.pool.get(id).to_owned();
         if self.pool.remove(&name).is_some() {
-            let bytes = name.len() * 2;
+            let bytes = name.len();
             self.mem_bytes -= bytes;
             #[cfg(test)]
             {


### PR DESCRIPTION
## Summary
- store a single allocation per pooled string by keeping raw pointers in the `StringPool`
- adjust `ScoreSet` string memory accounting to charge once per string instead of twice

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args
- cargo test
- cargo build --all-targets

------
https://chatgpt.com/codex/tasks/task_e_68c866b7320c83268a30eda1137e23fa