### PR TITLE
Align memory usage accounting with allocator measurements

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -39,7 +39,7 @@ pub unsafe extern "C" fn gzset_free(value: *mut c_void) {
 unsafe fn heap_size_of_score_set(set: &ScoreSet) -> usize {
     let mut total = ms(set as *const _ as *const _);
 
-    // tracked by ScoreSet::mem_bytes (buckets, member table, strings, by_score BTreeMap)
+    // tracked by ScoreSet::mem_bytes (buckets, member table, by_score BTreeMap)
     total += set.mem_bytes();
 
     // Add the auxiliary by_score_sizes BTreeMap overhead (keys + values).


### PR DESCRIPTION
## Summary
- stop treating string storage as part of `ScoreSet::mem_bytes` and expose a structural-only breakdown for tests
- recompute the expected allocator usage in unit tests with `RedisModule_MallocSize` and assert shrinking behavior during pops
- adjust the integration memory test to confirm `gzset_mem_usage` drops after removing members from a spilled bucket

## Testing
- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args
- cargo build --all-targets
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68c86abc89e08326a86c296a909d02d0