### PR TITLE
Use hashbrown map for string pool introspection

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,6 +1,5 @@
 #[cfg(not(feature = "fast-hash"))]
-use ahash::AHashMap;
-#[cfg(feature = "fast-hash")]
+use hashbrown::hash_map::DefaultHashBuilder;
 use hashbrown::HashMap;
 #[cfg(feature = "fast-hash")]
 use rustc_hash::FxHasher;
@@ -10,10 +9,12 @@ use std::ptr::NonNull;
 
 #[cfg(feature = "fast-hash")]
 /// FxHasher-based map used only when the `fast-hash` feature is enabled.
-pub type FastHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
+type FastHashBuilder = BuildHasherDefault<FxHasher>;
 #[cfg(not(feature = "fast-hash"))]
-/// Default to `AHashMap` for DOS-resistant hashing of user-provided names.
-pub type FastHashMap<K, V> = AHashMap<K, V>;
+/// Default to `AHash` for DOS-resistant hashing of user-provided names.
+type FastHashBuilder = DefaultHashBuilder;
+/// Hash map implementation used by the string pool.
+pub type FastHashMap<K, V> = HashMap<K, V, FastHashBuilder>;
 pub type MemberId = u32;
 
 #[derive(Default, Debug)]

--- a/src/score_set.rs
+++ b/src/score_set.rs
@@ -688,19 +688,14 @@ mod tests {
                 sizes_nodes * size_class(ScoreSet::map_node_bytes::<OrderedFloat<f64>, usize>());
         }
 
-        #[cfg(feature = "fast-hash")]
-        {
-            let table = set.pool.map.raw_table();
-            if table.capacity() > 0 {
-                let (ptr, _) = table.allocation_info();
-                total += ms(ptr.as_ptr().cast());
-                total += size_class(16 + table.buckets());
-            }
-        }
-        #[cfg(not(feature = "fast-hash"))]
-        {
-            if set.pool.map.capacity() > 0 {
-                total += size_class(16 + set.pool.map.capacity());
+        let table = set.pool.map.raw_table();
+        if table.buckets() > 0 {
+            let (ptr, layout) = table.allocation_info();
+            let table_bytes = ms(ptr.as_ptr().cast());
+            if table_bytes > 0 {
+                total += table_bytes;
+            } else {
+                total += size_class(layout.size());
             }
         }
 


### PR DESCRIPTION
## Summary
- back string pool's FastHashMap with hashbrown::HashMap in all feature configurations, swapping between FxHasher and the default AHash builder
- measure string pool table usage via raw_table allocation info with a layout-based fallback when Redis malloc introspection is unavailable
- align the score set memory accounting test helper with the new hash table reporting logic

## Testing
- cargo fmt -- --check
- cargo build --all-targets
- cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68c8712f14bc832680e33adaebab9e44