### PR TITLE
Replace string pool map with arena-backed storage

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,84 +1,242 @@
-#[cfg(not(feature = "fast-hash"))]
-use hashbrown::hash_map::DefaultHashBuilder;
-use hashbrown::HashMap;
+use hashbrown::{raw::RawTable, HashMap};
+use std::convert::TryInto;
+use std::fmt;
+use std::hash::{BuildHasher, Hasher};
+use std::str;
+
 #[cfg(feature = "fast-hash")]
 use rustc_hash::FxHasher;
 #[cfg(feature = "fast-hash")]
 use std::hash::BuildHasherDefault;
-use std::ptr::NonNull;
+
+#[cfg(not(feature = "fast-hash"))]
+use ahash::RandomState;
 
 #[cfg(feature = "fast-hash")]
-/// FxHasher-based map used only when the `fast-hash` feature is enabled.
-type FastHashBuilder = BuildHasherDefault<FxHasher>;
+type Build = BuildHasherDefault<FxHasher>;
 #[cfg(not(feature = "fast-hash"))]
-/// Default to `AHash` for DOS-resistant hashing of user-provided names.
-type FastHashBuilder = DefaultHashBuilder;
-/// Hash map implementation used by the string pool.
-pub type FastHashMap<K, V> = HashMap<K, V, FastHashBuilder>;
+type Build = RandomState;
+
+/// Hash map implementation used by the string pool and other helpers.
+pub type FastHashMap<K, V> = HashMap<K, V, Build>;
+
 pub type MemberId = u32;
 
-#[derive(Default, Debug)]
+// Encodes location inside the arena.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Loc {
+    chunk: u32,
+    off: u32,
+    len: u32,
+}
+
+// Entry we store in RawTable. No owned strings.
+pub(crate) struct KeyEntry {
+    hash: u64,
+    loc: Loc,
+    id: MemberId,
+}
+
+// Arena parameters
+const ARENA_CHUNK: usize = 4 * 1024 * 1024; // 4 MiB, tune if needed
+
 pub struct StringPool {
-    pub(crate) map: FastHashMap<Box<str>, MemberId>,
-    pub(crate) strings: Vec<Option<NonNull<str>>>,
+    hasher: Build,
+    // Big append-only chunks for string bytes
+    pub(crate) arena: Vec<Box<[u8]>>,
+    // Current write head into last chunk
+    write_chunk: usize, // index into arena
+    write_off: usize,   // offset into arena[write_chunk]
+    // Key lookup table: compares by bytes in arena
+    pub(crate) table: RawTable<KeyEntry>,
+    // id -> Loc mapping (None when freed)
+    pub(crate) index: Vec<Option<Loc>>,
+    // freelist of reusable ids
     pub(crate) free_ids: Vec<MemberId>,
+    // Fast length (live members)
+    len: usize,
+}
+
+impl Default for StringPool {
+    fn default() -> Self {
+        Self {
+            hasher: Build::default(),
+            arena: Vec::new(),
+            write_chunk: 0,
+            write_off: 0,
+            table: RawTable::new(),
+            index: Vec::new(),
+            free_ids: Vec::new(),
+            len: 0,
+        }
+    }
+}
+
+impl fmt::Debug for StringPool {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StringPool")
+            .field("arena_chunks", &self.arena.len())
+            .field("write_chunk", &self.write_chunk)
+            .field("write_off", &self.write_off)
+            .field("len", &self.len)
+            .field("allocated_ids", &self.index.len())
+            .finish()
+    }
 }
 
 impl StringPool {
     pub fn intern(&mut self, s: &str) -> MemberId {
-        if let Some(&id) = self.map.get(s) {
+        let bytes = s.as_bytes();
+        let hash = self.hash_bytes(bytes);
+        if let Some(entry) = self
+            .table
+            .get(hash, |entry| self.loc_bytes(entry.loc) == bytes)
+        {
+            return entry.id;
+        }
+
+        let loc = self.write_bytes(bytes);
+        let id = if let Some(id) = self.free_ids.pop() {
+            self.index[id as usize] = Some(loc);
             id
         } else {
-            let boxed: Box<str> = s.to_owned().into_boxed_str();
-            let ptr = NonNull::from(boxed.as_ref());
-            let id = if let Some(id) = self.free_ids.pop() {
-                self.strings[id as usize] = Some(ptr);
-                id
-            } else {
-                let id = self.strings.len() as MemberId;
-                self.strings.push(Some(ptr));
-                id
-            };
-            self.map.insert(boxed, id);
+            let idx = self.index.len();
+            let id: MemberId = idx.try_into().expect("too many members in string pool");
+            self.index.push(Some(loc));
             id
-        }
+        };
+
+        self.table
+            .insert(hash, KeyEntry { hash, loc, id }, |entry| entry.hash);
+        self.len += 1;
+        id
     }
 
     pub fn lookup(&self, s: &str) -> Option<MemberId> {
-        self.map.get(s).copied()
+        let bytes = s.as_bytes();
+        let hash = self.hash_bytes(bytes);
+        self.table
+            .get(hash, |entry| self.loc_bytes(entry.loc) == bytes)
+            .map(|entry| entry.id)
     }
 
     pub fn get(&self, id: MemberId) -> &str {
-        // SAFETY: `self.strings` stores pointers to allocations owned by `self.map`.
-        // Entries are cleared when removed, so dereferencing here is valid for live IDs.
-        unsafe {
-            self.strings[id as usize]
-                .as_ref()
-                .expect("invalid member id")
-                .as_ref()
-        }
+        let loc = self
+            .index
+            .get(id as usize)
+            .and_then(|loc| loc.as_ref())
+            .copied()
+            .expect("invalid member id");
+        self.loc_str(loc)
     }
 
     pub fn remove(&mut self, s: &str) -> Option<MemberId> {
-        if let Some(id) = self.map.remove(s) {
-            self.strings[id as usize] = None;
-            self.free_ids.push(id);
-            Some(id)
-        } else {
-            None
-        }
+        let bytes = s.as_bytes();
+        let hash = self.hash_bytes(bytes);
+        let (id, loc) = match self
+            .table
+            .get(hash, |entry| self.loc_bytes(entry.loc) == bytes)
+        {
+            Some(entry) => (entry.id, entry.loc),
+            None => return None,
+        };
+        let removed = self
+            .table
+            .remove_entry(hash, |entry| entry.id == id && entry.loc == loc);
+        debug_assert!(removed.is_some(), "entry must exist when removing");
+        self.index[id as usize] = None;
+        self.free_ids.push(id);
+        self.len -= 1;
+        Some(id)
     }
 
     pub fn len(&self) -> usize {
-        self.map.len()
+        self.len
     }
 
     pub fn allocated_ids(&self) -> usize {
-        self.strings.len()
+        self.index.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.map.is_empty()
+        self.len == 0
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&str, MemberId)> + '_ {
+        self.index.iter().enumerate().filter_map(move |(idx, loc)| {
+            let loc = loc.as_ref()?;
+            let id: MemberId = idx.try_into().expect("too many members in string pool");
+            Some((self.loc_str(*loc), id))
+        })
+    }
+
+    fn hash_bytes(&self, bytes: &[u8]) -> u64 {
+        let mut state = self.hasher.build_hasher();
+        state.write(bytes);
+        state.finish()
+    }
+
+    fn write_bytes(&mut self, bytes: &[u8]) -> Loc {
+        self.ensure_capacity(bytes.len());
+        let chunk_idx = self.write_chunk;
+        let start = self.write_off;
+        let end = start
+            .checked_add(bytes.len())
+            .expect("string pool offset overflow");
+        if !bytes.is_empty() {
+            self.arena[chunk_idx][start..end].copy_from_slice(bytes);
+        }
+        let loc = Loc {
+            chunk: chunk_idx
+                .try_into()
+                .expect("too many chunks in string pool"),
+            off: start
+                .try_into()
+                .expect("chunk offset exceeded supported range"),
+            len: bytes
+                .len()
+                .try_into()
+                .expect("string exceeds supported length"),
+        };
+        self.write_off = end;
+        loc
+    }
+
+    fn ensure_capacity(&mut self, needed: usize) {
+        if self.arena.is_empty() {
+            self.add_chunk(needed);
+            return;
+        }
+        let chunk_len = self.arena[self.write_chunk].len();
+        let end = self
+            .write_off
+            .checked_add(needed)
+            .expect("string pool offset overflow");
+        if end > chunk_len {
+            self.add_chunk(needed);
+        }
+    }
+
+    fn add_chunk(&mut self, needed: usize) {
+        let size = ARENA_CHUNK.max(needed);
+        let chunk = vec![0u8; size].into_boxed_slice();
+        self.arena.push(chunk);
+        self.write_chunk = self.arena.len() - 1;
+        self.write_off = 0;
+    }
+
+    fn loc_bytes(&self, loc: Loc) -> &[u8] {
+        let chunk_idx = loc.chunk as usize;
+        let off = loc.off as usize;
+        let len = loc.len as usize;
+        let end = off.checked_add(len).expect("string pool location overflow");
+        let chunk = &self.arena[chunk_idx];
+        &chunk[off..end]
+    }
+
+    fn loc_str(&self, loc: Loc) -> &str {
+        // SAFETY: bytes stored in the arena originate from valid UTF-8 strings.
+        unsafe { str::from_utf8_unchecked(self.loc_bytes(loc)) }
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the string pool’s boxed-string hash map with an arena-backed byte store and a RawTable keyed by arena offsets
- expose pool iteration for callers and update ScoreSet helpers/tests to consume the new API
- refresh memory accounting and integration tolerances to match the arena-backed layout

## Testing
- cargo fmt
- cargo build --all-targets
- cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68c9b433d7308326b8012426b5abac57