### PR TITLE
Inline small buckets and adjust shrink accounting

### DIFF
--- a/src/buckets.rs
+++ b/src/buckets.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom, mem::size_of};
+use std::{convert::TryFrom, mem, mem::size_of};
 
 use smallvec::SmallVec;
 
@@ -8,9 +8,62 @@ pub type BucketId = u32;
 
 const INLINE: usize = 4;
 
+#[derive(Debug)]
+pub(crate) enum Bucket {
+    Inline(SmallVec<[MemberId; INLINE]>),
+    Heap(Vec<MemberId>),
+}
+
+impl Bucket {
+    #[inline]
+    fn new_inline() -> Self {
+        Self::Inline(SmallVec::new())
+    }
+
+    #[inline]
+    fn is_heap(&self) -> bool {
+        matches!(self, Self::Heap(_))
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        match self {
+            Self::Inline(inline) => inline.len(),
+            Self::Heap(heap) => heap.len(),
+        }
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    #[inline]
+    fn capacity_bytes(&self) -> usize {
+        match self {
+            Self::Inline(_) => 0,
+            Self::Heap(heap) => heap.capacity() * size_of::<MemberId>(),
+        }
+    }
+
+    #[inline]
+    fn as_slice(&self) -> &[MemberId] {
+        match self {
+            Self::Inline(inline) => inline.as_slice(),
+            Self::Heap(heap) => heap.as_slice(),
+        }
+    }
+}
+
+impl Default for Bucket {
+    fn default() -> Self {
+        Self::new_inline()
+    }
+}
+
 #[derive(Default, Debug)]
 pub struct BucketStore {
-    pub(crate) buckets: Vec<Option<SmallVec<[MemberId; INLINE]>>>,
+    pub(crate) buckets: Vec<Option<Bucket>>,
     pub(crate) free: Vec<BucketId>,
 }
 
@@ -19,14 +72,14 @@ impl BucketStore {
         Self::default()
     }
 
-    fn bucket(&self, id: BucketId) -> &SmallVec<[MemberId; INLINE]> {
+    fn bucket(&self, id: BucketId) -> &Bucket {
         self.buckets
             .get(id as usize)
             .and_then(|slot| slot.as_ref())
             .expect("invalid bucket id")
     }
 
-    fn bucket_mut(&mut self, id: BucketId) -> &mut SmallVec<[MemberId; INLINE]> {
+    fn bucket_mut(&mut self, id: BucketId) -> &mut Bucket {
         self.buckets
             .get_mut(id as usize)
             .and_then(|slot| slot.as_mut())
@@ -40,12 +93,12 @@ impl BucketStore {
                 .get_mut(id as usize)
                 .expect("reused bucket id out of bounds");
             debug_assert!(slot.is_none(), "reused bucket slot must be empty");
-            *slot = Some(SmallVec::new());
+            *slot = Some(Bucket::new_inline());
             id
         } else {
             let idx = self.buckets.len();
             let id = BucketId::try_from(idx).expect("too many buckets allocated");
-            self.buckets.push(Some(SmallVec::new()));
+            self.buckets.push(Some(Bucket::new_inline()));
             id
         }
     }
@@ -57,11 +110,7 @@ impl BucketStore {
             .expect("invalid bucket id");
         if let Some(bucket) = slot {
             if bucket.is_empty() {
-                let spilled_bytes = if bucket.spilled() {
-                    bucket.capacity() * size_of::<MemberId>()
-                } else {
-                    0
-                };
+                let spilled_bytes = bucket.capacity_bytes();
                 *slot = None;
                 self.free.push(id);
                 let delta = if spilled_bytes == 0 {
@@ -89,20 +138,44 @@ impl BucketStore {
         F: Fn(MemberId) -> &'a str,
     {
         let bucket = self.bucket_mut(id);
-        let spilled_before = bucket.spilled();
+        let spilled_before = bucket.is_heap();
         let member_name = cmp_name(member);
-        match bucket.binary_search_by(|&m| cmp_name(m).cmp(member_name)) {
-            Ok(pos) => (false, 0, spilled_before, bucket.spilled(), pos),
-            Err(pos) => {
-                bucket.insert(pos, member);
-                let spilled_after = bucket.spilled();
-                let mut delta = 0isize;
-                if !spilled_before && spilled_after {
-                    let bytes = bucket.capacity() * size_of::<MemberId>();
-                    delta = isize::try_from(bytes).expect("bucket spill delta overflow");
+        match bucket {
+            Bucket::Inline(inline) => match inline
+                .binary_search_by(|&m| cmp_name(m).cmp(member_name))
+            {
+                Ok(pos) => (false, 0, spilled_before, false, pos),
+                Err(pos) => {
+                    if inline.len() == INLINE {
+                        let existing = mem::take(inline);
+                        let mut heap = Vec::with_capacity(INLINE * 2);
+                        heap.extend(existing);
+                        heap.insert(pos, member);
+                        let bytes = heap.capacity() * size_of::<MemberId>();
+                        let delta = isize::try_from(bytes).expect("bucket spill delta overflow");
+                        *bucket = Bucket::Heap(heap);
+                        (true, delta, spilled_before, true, pos)
+                    } else {
+                        inline.insert(pos, member);
+                        (true, 0, spilled_before, false, pos)
+                    }
                 }
-                (true, delta, spilled_before, spilled_after, pos)
-            }
+            },
+            Bucket::Heap(heap) => match heap.binary_search_by(|&m| cmp_name(m).cmp(member_name)) {
+                Ok(pos) => (false, 0, spilled_before, true, pos),
+                Err(pos) => {
+                    let cap_before = heap.capacity();
+                    heap.insert(pos, member);
+                    let cap_after = heap.capacity();
+                    let delta = if cap_after > cap_before {
+                        let bytes = (cap_after - cap_before) * size_of::<MemberId>();
+                        isize::try_from(bytes).expect("bucket spill delta overflow")
+                    } else {
+                        0
+                    };
+                    (true, delta, spilled_before, true, pos)
+                }
+            },
         }
     }
 
@@ -116,34 +189,49 @@ impl BucketStore {
         F: Fn(MemberId) -> &'a str,
     {
         let bucket = self.bucket_mut(id);
-        match bucket.binary_search_by(|&m| cmp_name(m).cmp(name)) {
-            Ok(pos) => {
-                bucket.remove(pos);
-                (true, 0, bucket.is_empty())
-            }
-            Err(_) => (false, 0, false),
+        match bucket {
+            Bucket::Inline(inline) => match inline.binary_search_by(|&m| cmp_name(m).cmp(name)) {
+                Ok(pos) => {
+                    inline.remove(pos);
+                    (true, 0, inline.is_empty())
+                }
+                Err(_) => (false, 0, false),
+            },
+            Bucket::Heap(heap) => match heap.binary_search_by(|&m| cmp_name(m).cmp(name)) {
+                Ok(pos) => {
+                    heap.remove(pos);
+                    (true, 0, heap.is_empty())
+                }
+                Err(_) => (false, 0, false),
+            },
         }
     }
 
     pub fn maybe_shrink(&mut self, id: BucketId, threshold: usize) -> isize {
         let bucket = self.bucket_mut(id);
-        if bucket.spilled() && bucket.len() <= threshold {
-            let bytes = bucket.capacity() * size_of::<MemberId>();
-            bucket.shrink_to_fit();
-            let bytes = isize::try_from(bytes).expect("bucket shrink delta overflow");
-            -bytes
+        let limit = threshold.min(INLINE);
+        let should_shrink = matches!(bucket, Bucket::Heap(heap) if heap.len() <= limit);
+        if should_shrink {
+            let old_bucket = mem::take(bucket);
+            if let Bucket::Heap(old_heap) = old_bucket {
+                let bytes = old_heap.capacity() * size_of::<MemberId>();
+                if let Bucket::Inline(inline) = bucket {
+                    inline.extend(old_heap);
+                } else {
+                    unreachable!("bucket must be inline after replacement");
+                }
+                let bytes = isize::try_from(bytes).expect("bucket shrink delta overflow");
+                -bytes
+            } else {
+                unreachable!("expected heap bucket when shrinking");
+            }
         } else {
             0
         }
     }
 
     pub fn capacity_bytes(&self, id: BucketId) -> usize {
-        let bucket = self.bucket(id);
-        if bucket.spilled() {
-            bucket.capacity() * size_of::<MemberId>()
-        } else {
-            0
-        }
+        self.bucket(id).capacity_bytes()
     }
 
     pub fn len(&self, id: BucketId) -> usize {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,6 +1,9 @@
-use crate::{buckets::BucketStore, pool::Loc, pool::MemberId, score_set::ScoreSet};
+use crate::{
+    buckets::{Bucket, BucketStore},
+    pool::Loc,
+    score_set::ScoreSet,
+};
 use redis_module::raw::RedisModule_MallocSize;
-use smallvec::SmallVec;
 use std::mem::size_of;
 use std::os::raw::c_void;
 
@@ -70,7 +73,7 @@ unsafe fn heap_size_of_score_set(set: &ScoreSet) -> usize {
         if alloc_bytes > 0 {
             total += alloc_bytes;
         } else {
-            let elem_size = size_of::<Option<SmallVec<[MemberId; 4]>>>();
+            let elem_size = size_of::<Option<Bucket>>();
             total += size_class(buckets_cap * elem_size);
         }
     }


### PR DESCRIPTION
## Summary
- represent buckets with an inline-or-heap enum and update insert/remove paths to manage transitions without extra Vec headers.【F:src/buckets.rs†L11-L209】
- update memory usage estimation to size Option<Bucket> slots instead of SmallVec wrappers.【F:src/memory.rs†L1-L88】
- tighten bucket shrink tests to assert freed bytes match heap capacity and ensure inline state restoration.【F:src/score_set.rs†L1070-L1138】

## Testing
- `cargo fmt`【6d53b7†L1-L2】
- `cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args`【525cac†L1-L2】
- `cargo build --all-targets`【1b6790†L1-L2】
- `cargo test | tail -n 20`【858600†L1-L20】

------
https://chatgpt.com/codex/tasks/task_e_68cb14b1df848326b561c26d75ff1aa3