### PR TITLE
Inline bucket singletons and simplify bucket store

### DIFF
--- a/tests/score_set.rs
+++ b/tests/score_set.rs
@@ -75,7 +75,7 @@ fn grow_and_shrink_bucket() {
     assert!(set.bucket_capacity_for_test(1.0).is_some_and(|c| c > 4));
     set.remove("a");
     set.remove("b");
-    assert_eq!(set.bucket_capacity_for_test(1.0), Some(4));
+    assert_eq!(set.bucket_capacity_for_test(1.0), Some(3));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- inline single-member buckets via a new `BucketRef` enum and a heap-only `BucketStore`
- update `ScoreSet` iterators and mutation paths to convert between inline and handled buckets with correct memory tracking
- add regression tests for singleton buckets and adjust shrink expectations for heaps

## Testing
- cargo fmt
- cargo build --all-targets
- cargo test
- cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args

------
https://chatgpt.com/codex/tasks/task_e_68cb2298ee148326a1eb9e3a15efaca1