### PR TITLE
Stream gzpop visits and batch bucket drains

### DIFF
--- a/benches/gzpop.rs
+++ b/benches/gzpop.rs
@@ -13,11 +13,29 @@ fn bench_pop(c: &mut Criterion) {
             let _ = set.pop_all(true);
         })
     });
+    group.bench_function("pop_min_same_score", |b| {
+        b.iter(|| {
+            let mut set = ScoreSet::default();
+            for (_, m) in &entries {
+                set.insert(0.0, m);
+            }
+            let _ = set.pop_all(true);
+        })
+    });
     group.bench_function("pop_max", |b| {
         b.iter(|| {
             let mut set = ScoreSet::default();
             for (s, m) in &entries {
                 set.insert(*s, m);
+            }
+            let _ = set.pop_all(false);
+        })
+    });
+    group.bench_function("pop_max_same_score", |b| {
+        b.iter(|| {
+            let mut set = ScoreSet::default();
+            for (_, m) in &entries {
+                set.insert(0.0, m);
             }
             let _ = set.pop_all(false);
         })

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -162,6 +162,20 @@ impl StringPool {
         Some(id)
     }
 
+    pub fn remove_by_id(&mut self, id: MemberId) -> Option<usize> {
+        let slot = self.index.get_mut(id as usize)?;
+        let loc = slot.take()?;
+        let (hash, len) = {
+            let bytes = self.loc_bytes(loc);
+            (self.hash_bytes(bytes), bytes.len())
+        };
+        let removed = self.table.remove_entry(hash, |entry| entry.id == id);
+        debug_assert!(removed.is_some(), "entry must exist when removing by id");
+        self.free_ids.push(id);
+        self.len -= 1;
+        Some(len)
+    }
+
     pub fn len(&self) -> usize {
         self.len
     }


### PR DESCRIPTION
## Summary
- stream multiple pops via `ScoreSet::pop_n_visit`, reuse a new string-pool removal helper, and add a regression test covering singleton/empty transitions
- add bucket drain helpers that batch removal from fronts/backs to avoid repeated memmoves
- emit gzpop replies directly through the raw API and extend the bench suite with adversarial same-score cases

## Testing
- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args`
- `cargo test`
- `cargo build --all-targets`


------
https://chatgpt.com/codex/tasks/task_e_68cc789ab014832682c870c3fba46af1