### PR TITLE
Add forward range iterator for gzrange

### DIFF
--- a/benches/gzrange.rs
+++ b/benches/gzrange.rs
@@ -11,7 +11,7 @@ fn bench_range(c: &mut Criterion) {
             for (s, m) in &entries {
                 set.insert(*s, m);
             }
-            let mut iter = set.iter_range(0, entries.len() as isize - 1);
+            let mut iter = set.iter_range_fwd(0, entries.len() as isize - 1);
             for _ in &mut iter {}
         })
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub use crate::{
     command::register_commands,
     format::{fmt_f64, with_fmt_buf},
     pool::{FastHashMap, MemberId, StringPool},
-    score_set::{ScoreIter, ScoreSet},
+    score_set::{RangeIterFwd, ScoreIter, ScoreSet},
 };
 
 mod buckets;

--- a/tests/gzrange.rs
+++ b/tests/gzrange.rs
@@ -20,3 +20,39 @@ fn gzrange_large_stream() -> redis::RedisResult<()> {
     assert_eq!(res, expected);
     Ok(())
 }
+
+#[test]
+fn gzrange_negative_indices() -> redis::RedisResult<()> {
+    let vk = helpers::ValkeyInstance::start();
+    let mut con = redis::Client::open(vk.url())?.get_connection()?;
+
+    for i in 0..5 {
+        redis::cmd("GZADD")
+            .arg("s")
+            .arg(i)
+            .arg(format!("m{i}"))
+            .query::<()>(&mut con)?;
+    }
+
+    let res: Vec<String> = redis::cmd("GZRANGE")
+        .arg("s")
+        .arg(-3)
+        .arg(-1)
+        .query(&mut con)?;
+    assert_eq!(res, vec!["m2", "m3", "m4"]);
+    Ok(())
+}
+
+#[test]
+fn gzrange_empty_set() -> redis::RedisResult<()> {
+    let vk = helpers::ValkeyInstance::start();
+    let mut con = redis::Client::open(vk.url())?.get_connection()?;
+
+    let res: Vec<String> = redis::cmd("GZRANGE")
+        .arg("missing")
+        .arg(0)
+        .arg(-1)
+        .query(&mut con)?;
+    assert!(res.is_empty());
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- introduce a forward-only `RangeIterFwd` for `ScoreSet` and reuse it for range helpers
- optimize `GZRANGE` index parsing and add a fast path for full-range scans using the new iterator
- extend the benchmark and add tests covering negative indices and empty-set handling

## Testing
- `cargo build --all-targets`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args`


------
https://chatgpt.com/codex/tasks/task_e_68cc7f013a8883269a613d9ff70cbeaa