### PR TITLE
Use windowed buckets to avoid pop memmoves

### DIFF
--- a/benches/gzpop.rs
+++ b/benches/gzpop.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use gzset::ScoreSet;
 
 fn bench_pop(c: &mut Criterion) {
@@ -38,6 +38,30 @@ fn bench_pop(c: &mut Criterion) {
                 set.insert(0.0, m);
             }
             let _ = set.pop_all(false);
+        })
+    });
+    group.bench_function("pop_min_n1_same_score", |b| {
+        b.iter(|| {
+            let mut set = ScoreSet::default();
+            for (_, m) in &entries {
+                set.insert(0.0, m);
+            }
+            for _ in 0..100 {
+                let popped = set.pop_n(true, 1);
+                black_box(&popped);
+            }
+        })
+    });
+    group.bench_function("pop_max_n1_same_score", |b| {
+        b.iter(|| {
+            let mut set = ScoreSet::default();
+            for (_, m) in &entries {
+                set.insert(0.0, m);
+            }
+            for _ in 0..100 {
+                let popped = set.pop_n(false, 1);
+                black_box(&popped);
+            }
         })
     });
     group.finish();


### PR DESCRIPTION
## Summary
- replace the Vec-backed bucket with a windowed Bucket struct so draining front/back is O(1)
- update BucketStore operations to use the sliding window and compact when shrinking
- add Criterion benchmarks that stress repeated pop_n(min/max, 1) calls on a single-score bucket

## Testing
- cargo fmt -- --check
- cargo build --all-targets
- cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cc8b1d063483268aa681cfb3f42ecf