### PR TITLE
Cache formatted score per score group

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -249,20 +249,15 @@ fn gzpop_generic(ctx: &Context, args: Vec<RedisString>, min: bool) -> Result {
             RedisModule_ReplyWithArray.unwrap()(raw, REDISMODULE_POSTPONED_ARRAY_LEN as c_long)
         };
         let mut pairs = 0usize;
-        set.pop_n_visit(min, count, |name, score| {
+        set.pop_n_visit(min, count, |name, _score, score_s| {
             unsafe {
                 RedisModule_ReplyWithStringBuffer.unwrap()(raw, name.as_ptr().cast(), name.len());
+                RedisModule_ReplyWithStringBuffer.unwrap()(
+                    raw,
+                    score_s.as_ptr().cast(),
+                    score_s.len(),
+                );
             }
-            with_fmt_buf(|b| {
-                let formatted = fmt_f64(b, score);
-                unsafe {
-                    RedisModule_ReplyWithStringBuffer.unwrap()(
-                        raw,
-                        formatted.as_ptr().cast(),
-                        formatted.len(),
-                    );
-                }
-            });
             pairs += 1;
         });
         unsafe { RedisModule_ReplySetArrayLength.unwrap()(raw, (pairs * 2) as c_long) };


### PR DESCRIPTION
## Summary
- compute the formatted score string once per score group in `ScoreSet::pop_n_visit`
- pass the cached string to `gzpop` responses so repeated members reuse it instead of reformatting

## Testing
- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args
- cargo build --all-targets
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d1a00066188326820dda3c047ce1bf