### PR TITLE
Make valkey-flame run until stopped

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ server already listening on 6379.
 ### Profiling with perf (Linux)
 
 ```bash
-# 1) Generate a flamegraph for 20s while you drive load (in another shell)
-cargo valkey-flame --duration 20
+# 1) Generate a flamegraph while you drive load (press Ctrl-C when done, or pass --duration to stop automatically)
+cargo valkey-flame
 
 # 2) In a separate shell, drive a workload (example):
 valkey-cli -p 6379 <<'EOS'
@@ -86,8 +86,8 @@ macOS is supported too via Apple's `sample` profiler; see below.
 ### Profiling with sample (macOS)
 
 ```bash
-# 1) Generate a flamegraph for 20s while you drive load (in another shell)
-cargo valkey-flame --duration 20
+# 1) Generate a flamegraph while you drive load (press Ctrl-C when done, or pass --duration to stop automatically)
+cargo valkey-flame
 
 # 2) In a separate shell, drive a workload (example):
 valkey-cli -p 6379 <<'EOS'


### PR DESCRIPTION
## Summary
- remove the hard-coded 20 second default duration from the `valkey-flame` xtask and make the profiler run until it is terminated
- allow an explicit `--duration` override and update the Linux/macOS helper commands to build the profiler invocation dynamically
- refresh the README examples to explain the new default behaviour and how to supply a duration

## Testing
- cargo fmt -- --check
- cargo build --all-targets
- cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68d2ebea6e888326bd33d8cf6a5d9363