### PR TITLE
Keep macOS sampling running until interrupted

### DIFF
--- a/src/bin/xtask.rs
+++ b/src/bin/xtask.rs
@@ -422,22 +422,24 @@ fn flame_macos(
     let sample_name = "sample.txt";
     let sample_path = out_path.join(sample_name);
 
+    // sample(1) defaults to 10s; use a long duration so Ctrl-C stops it instead.
+    const DEFAULT_SAMPLE_DURATION: u64 = 999_999;
+    let sample_duration = duration.unwrap_or(DEFAULT_SAMPLE_DURATION);
     if duration.is_none() {
         println!("=> sampling until sample is terminated (press Ctrl-C to stop)");
     }
 
-    let sample_cmd_str = if let Some(duration) = duration {
-        format!("sample {pid} {duration} -file {sample_name}")
+    let sample_cmd_suffix = if duration.is_none() {
+        " (Ctrl-C to stop)"
     } else {
-        format!("sample {pid} -file {sample_name}")
+        ""
     };
-    println!("=> running: {sample_cmd_str}");
+    println!("=> running: sample {pid} {sample_duration} -file {sample_name}{sample_cmd_suffix}");
 
     let mut sample_cmd = Command::new("sample");
-    sample_cmd.arg(pid.to_string());
-    if let Some(duration) = duration {
-        sample_cmd.arg(duration.to_string());
-    }
+    sample_cmd
+        .arg(pid.to_string())
+        .arg(sample_duration.to_string());
     sample_cmd
         .arg("-file")
         .arg(sample_name)


### PR DESCRIPTION
## Summary
- supply a long default sampling duration on macOS so `cargo valkey-flame` continues until interrupted
- adjust the printed sample command to reflect the long-running default and mention Ctrl-C explicitly

## Testing
- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args
- cargo build --all-targets
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d300d7a1f883268d4c0845d3f86895