### PR TITLE
Handle Ctrl-C while profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,7 @@ dependencies = [
  "criterion",
  "hashbrown",
  "heck 0.5.0",
+ "libc",
  "once_cell",
  "ordered-float",
  "portpicker",
@@ -477,6 +478,7 @@ dependencies = [
  "redis-module",
  "rustc-hash",
  "ryu",
+ "signal-hook",
  "smallvec",
  "which",
 ]
@@ -1192,6 +1194,25 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ ahash = "0.8"
 clap = { version = "4", features = ["derive"] }
 portpicker = "0.1"
 redis = "0.25"
+libc = "0.2"
+signal-hook = "0.3"
 heck = "0.5"
 rand = "0.8"
 


### PR DESCRIPTION
## Summary
- add the signal-hook crate to install a temporary SIGINT handler while profiling
- guard the profiler waits so Ctrl-C stops the profiler but keeps xtask running long enough to collapse stacks and emit the flamegraph
- update the Linux perf and macOS sample runners to spawn the profiler explicitly and wait through the new helper so flame.svg is produced on interrupts

## Testing
- cargo fmt -- --check
- cargo build --all-targets
- cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d30fcfd0088326864fb7596806000e