### PR TITLE
Optimize gzpop to avoid allocations

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,1 @@
-fn main() {
-    println!("cargo:rustc-check-cfg=cfg(reply_double_default)");
-    if std::env::var("CARGO_CFG_TARGET_OS")
-        .map(|target| target == "linux")
-        .unwrap_or(false)
-    {
-        println!("cargo:rustc-cfg=reply_double_default");
-    }
-}
+fn main() {}


### PR DESCRIPTION
## Summary
- add peek_pop_count and pop_one_visit helpers so gzpop can emit members without allocating Strings
- replace the batch pop scratch Vec with SmallVec to avoid heap work for small batches
- prefer RedisModule_ReplyWithDouble when available and pre-size gzpop arrays, removing the Linux-only build gate

## Testing
- cargo fmt
- cargo build --all-targets
- cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d3267c09c883269e1c2e8594c9a0de