### PR TITLE
Cache string pool hashes

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,6 +1,6 @@
 use crate::{
     buckets::{Bucket, BucketStore},
-    pool::Loc,
+    pool::IndexEntry,
     score_set::ScoreSet,
 };
 use redis_module::raw::RedisModule_MallocSize;
@@ -49,7 +49,7 @@ unsafe fn heap_size_of_score_set(set: &ScoreSet) -> usize {
         }
     }
     if set.pool.index.capacity() > 0 {
-        total += size_class(set.pool.index.capacity() * size_of::<Option<Loc>>());
+        total += size_class(set.pool.index.capacity() * size_of::<Option<IndexEntry>>());
     }
     if set.pool.free_ids.capacity() > 0 {
         total += size_class(set.pool.free_ids.capacity() * size_of::<crate::pool::MemberId>());

--- a/src/score_set.rs
+++ b/src/score_set.rs
@@ -1221,7 +1221,7 @@ mod tests {
     use super::*;
     use crate::buckets::{Bucket, BucketRef, BucketStore};
     use crate::memory::gzset_mem_usage;
-    use crate::pool::{Loc, MemberId};
+    use crate::pool::{IndexEntry, MemberId};
     use ordered_float::OrderedFloat;
     use rand::{rngs::StdRng, Rng, SeedableRng};
     use redis_module::raw::RedisModule_MallocSize;
@@ -1256,7 +1256,7 @@ mod tests {
         }
 
         if set.pool.index.capacity() > 0 {
-            total += size_class(set.pool.index.capacity() * size_of::<Option<Loc>>());
+            total += size_class(set.pool.index.capacity() * size_of::<Option<IndexEntry>>());
         }
         if set.pool.free_ids.capacity() > 0 {
             total += size_class(set.pool.free_ids.capacity() * size_of::<MemberId>());


### PR DESCRIPTION
## Summary
- add an IndexEntry wrapper that stores both the arena location and cached hash for each string pool member
- update the pool fast paths to reuse the cached hash, avoid re-reading arena bytes, and adjust iter/get helpers accordingly
- refresh memory accounting code and tests to size Option<IndexEntry> entries instead of Option<Loc>

## Testing
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args`
- `cargo test`
- `cargo build --all-targets`


------
https://chatgpt.com/codex/tasks/task_e_68d43a330234832688c13cd6d8804d80