### PR TITLE
Disable gzset persistence hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Each `GZSET` key owns its B-tree data directly, so `MEMORY USAGE` reflects the e
 |---------------------|-------|-------|
 | Core commands       | ✅   | `GZADD / GZREM / GZRANGE / GZRANK / GZPOPMIN / GZPOPMAX …` |
 | Valkey‑side unit tests | ✅   | Runs in CI on every push |
-| RDB/AOF persistence | 🚧   | Stubbed; data is in‑memory only today |
+| RDB/AOF persistence | ❌   | Explicitly non‑persistent; keys are volatile |
 | GPU‑learned index   | ⏸   | Prototype branch retained, not in `main` |
 | Cluster support     | ❌   | Single‑node only for now |
 | MEMORY USAGE key | reports exact usage | ✅ |

--- a/src/bin/xtask.rs
+++ b/src/bin/xtask.rs
@@ -210,7 +210,7 @@ fn spawn_valkey(
         .arg("--loadmodule")
         .arg(&so_path)
         .arg("--save")
-        .arg("") // disable RDB
+        .arg("") // disable RDB; keep gzset non-persistent in production until an RDB format exists
         .arg("--daemonize")
         .arg("no")
         .stdin(Stdio::null())

--- a/src/command.rs
+++ b/src/command.rs
@@ -19,8 +19,8 @@ pub static GZSET_TYPE: rm::native_types::RedisType = rm::native_types::RedisType
     0,
     raw::RedisModuleTypeMethods {
         version: raw::REDISMODULE_TYPE_METHOD_VERSION as u64,
-        rdb_load: Some(gzset_rdb_load),
-        rdb_save: Some(gzset_rdb_save),
+        rdb_load: None,
+        rdb_save: None,
         aof_rewrite: None,
         free: Some(crate::memory::gzset_free),
         mem_usage: Some(crate::memory::gzset_mem_usage),
@@ -39,12 +39,6 @@ pub static GZSET_TYPE: rm::native_types::RedisType = rm::native_types::RedisType
         unlink2: None,
     },
 );
-
-unsafe extern "C" fn gzset_rdb_load(_io: *mut raw::RedisModuleIO, _encver: c_int) -> *mut c_void {
-    std::ptr::null_mut()
-}
-
-unsafe extern "C" fn gzset_rdb_save(_io: *mut raw::RedisModuleIO, _value: *mut c_void) {}
 
 fn with_set_write<F, R>(ctx: &Context, key: &RedisString, f: F) -> rm::RedisResult<R>
 where


### PR DESCRIPTION
## Summary
- disable the gzset RedisModule type's persistence hooks to opt out of RDB/AOF
- document that keys are explicitly non-persistent in the README
- note in `xtask` that production deployments must keep persistence disabled until an RDB format exists

## Testing
- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args
- cargo build --all-targets
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d47448831c832698da98af9ad59c79