### PR TITLE
Drop cached hash from pool index

### DIFF
--- a/src/score_set.rs
+++ b/src/score_set.rs
@@ -1112,13 +1112,15 @@ impl ScoreSet {
             let score = score_key.0;
             match bucket_ref {
                 BucketRef::Inline1(member_id) => {
-                    {
+                    let name_owned = {
                         let name = self.pool.get(member_id);
                         visit(name, score);
-                    }
+                        name.to_owned()
+                    };
                     self.clear_score_slot(member_id);
-                    let removed = self.pool.remove_by_id(member_id);
-                    self.account_removed_string(removed);
+                    let name_len = name_owned.len();
+                    let removed = self.pool.remove(&name_owned).is_some();
+                    self.account_removed_string(if removed { Some(name_len) } else { None });
                     if prev_map.is_none() {
                         prev_map = Some(Self::score_map_bytes(&self.by_score));
                     }
@@ -1145,13 +1147,15 @@ impl ScoreSet {
                     }
 
                     for &member_id in &member_buffer {
-                        {
+                        let name_owned = {
                             let name = self.pool.get(member_id);
                             visit(name, score);
-                        }
+                            name.to_owned()
+                        };
                         self.clear_score_slot(member_id);
-                        let removed = self.pool.remove_by_id(member_id);
-                        self.account_removed_string(removed);
+                        let name_len = name_owned.len();
+                        let removed = self.pool.remove(&name_owned).is_some();
+                        self.account_removed_string(if removed { Some(name_len) } else { None });
                     }
 
                     let popped_here = member_buffer.len();


### PR DESCRIPTION
## Summary
- Remove the cached hash from `IndexEntry`, storing only the arena location and rehashing on removal as needed
- Update pop paths to remove members from the pool by name and preserve string length accounting while visiting results

## Testing
- `cargo build --all-targets`
- `cargo test --all --all-targets --verbose`
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args`


------
https://chatgpt.com/codex/tasks/task_e_68d5c790a6248326a24eca37ee364563