### PR TITLE
Harden Criterion benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ name = "gzrange"
 harness = false
 required-features = ["bench"]
 
+[[bench]]
+name = "gzadd_tied"
+harness = false
+required-features = ["bench"]
+
 [dependencies]
 redis-module = "2.0.7"
 once_cell = "1"

--- a/benches/gzpop.rs
+++ b/benches/gzpop.rs
@@ -1,15 +1,38 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::time::Duration;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use gzset::ScoreSet;
 
-const ENTRY_COUNT: usize = 100_000;
-const REPEAT_POPS: usize = 50;
+const DEFAULT_ENTRY_COUNT: usize = 100_000;
+const DEFAULT_REPEAT_POPS: usize = 50;
+
+fn entry_count() -> usize {
+    std::env::var("BENCH_ENTRY_COUNT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_ENTRY_COUNT)
+}
+
+fn repeat_pops() -> usize {
+    std::env::var("BENCH_REPEAT_POPS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_REPEAT_POPS)
+}
 
 fn bench_pop(c: &mut Criterion) {
-    let members: Vec<String> = (0..ENTRY_COUNT).map(|i| format!("member:{i}")).collect();
+    let entry_count = entry_count();
+    let repeat_pops = repeat_pops();
+    let members: Vec<String> = (0..entry_count).map(|i| format!("member:{i}")).collect();
 
     let mut group = c.benchmark_group("pop_loop_vs_baseline");
+    group.measurement_time(Duration::from_secs(8));
+    group.warm_up_time(Duration::from_secs(2));
     group.sample_size(10);
 
+    let entry_count_throughput = Throughput::Elements(entry_count as u64);
+
+    group.throughput(entry_count_throughput);
     group.bench_function("pop_min", |b| {
         b.iter(|| {
             let mut set = ScoreSet::default();
@@ -20,6 +43,7 @@ fn bench_pop(c: &mut Criterion) {
         })
     });
 
+    group.throughput(entry_count_throughput);
     group.bench_function("pop_min_same_score", |b| {
         b.iter(|| {
             let mut set = ScoreSet::default();
@@ -30,6 +54,7 @@ fn bench_pop(c: &mut Criterion) {
         })
     });
 
+    group.throughput(entry_count_throughput);
     group.bench_function("pop_max", |b| {
         b.iter(|| {
             let mut set = ScoreSet::default();
@@ -40,6 +65,7 @@ fn bench_pop(c: &mut Criterion) {
         })
     });
 
+    group.throughput(entry_count_throughput);
     group.bench_function("pop_max_same_score", |b| {
         b.iter(|| {
             let mut set = ScoreSet::default();
@@ -50,52 +76,58 @@ fn bench_pop(c: &mut Criterion) {
         })
     });
 
+    let repeat_throughput = Throughput::Elements(repeat_pops as u64);
+
+    group.throughput(repeat_throughput);
     group.bench_function("pop_min_n1_same_score", |b| {
         b.iter(|| {
             let mut set = ScoreSet::default();
             for member in &members {
                 set.insert(0.0, member);
             }
-            for _ in 0..REPEAT_POPS {
+            for _ in 0..repeat_pops {
                 let popped = set.pop_n(true, 1);
                 black_box(&popped);
             }
         })
     });
 
+    group.throughput(repeat_throughput);
     group.bench_function("pop_max_n1_same_score", |b| {
         b.iter(|| {
             let mut set = ScoreSet::default();
             for member in &members {
                 set.insert(0.0, member);
             }
-            for _ in 0..REPEAT_POPS {
+            for _ in 0..repeat_pops {
                 let popped = set.pop_n(false, 1);
                 black_box(&popped);
             }
         })
     });
 
+    group.throughput(repeat_throughput);
     group.bench_function("pop_min_one_same_score", |b| {
         b.iter(|| {
             let mut set = ScoreSet::default();
             for member in &members {
                 set.insert(0.0, member);
             }
-            for _ in 0..REPEAT_POPS {
+            for _ in 0..repeat_pops {
                 let popped = set.pop_one(true);
                 black_box(&popped);
             }
         })
     });
 
+    group.throughput(repeat_throughput);
     group.bench_function("pop_max_one_same_score", |b| {
         b.iter(|| {
             let mut set = ScoreSet::default();
             for member in &members {
                 set.insert(0.0, member);
             }
-            for _ in 0..REPEAT_POPS {
+            for _ in 0..repeat_pops {
                 let popped = set.pop_one(false);
                 black_box(&popped);
             }


### PR DESCRIPTION
## Summary
- register the `gzadd_tied` Criterion benchmark so it runs without the test harness
- stabilize the `gzrange` measurements with fixed timing, flat sampling, and throughput reporting
- tune the `gzpop` benchmark timings, expose entry/pops counts via env vars, and report throughput

## Testing
- cargo fmt
- cargo build --all-targets
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d6ea46d8508326be5721ceaa971fe3