### PR TITLE
Expand Criterion benchmarks and add shared support harness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,36 @@ name = "gzadd_tied"
 harness = false
 required-features = ["bench"]
 
+[[bench]]
+name = "gzadd"
+harness = false
+required-features = ["bench"]
+
+[[bench]]
+name = "gzrem"
+harness = false
+required-features = ["bench"]
+
+[[bench]]
+name = "lookup"
+harness = false
+required-features = ["bench"]
+
+[[bench]]
+name = "gzrand"
+harness = false
+required-features = ["bench"]
+
+[[bench]]
+name = "algebra"
+harness = false
+required-features = ["bench"]
+
+[[bench]]
+name = "gzscan"
+harness = false
+required-features = ["bench"]
+
 [dependencies]
 redis-module = "2.0.7"
 once_cell = "1"

--- a/benches/algebra.rs
+++ b/benches/algebra.rs
@@ -1,5 +1,8 @@
+use std::time::Duration;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use gzset::{FastHashMap, ScoreSet};
+use gzset::ScoreSet;
+use rustc_hash::FxHashMap as FastHashMap;
 
 mod support;
 
@@ -14,6 +17,10 @@ fn bench_algebra(c: &mut Criterion) {
     ];
 
     let mut group = c.benchmark_group("algebra");
+    group.measurement_time(Duration::from_secs(10));
+    group.warm_up_time(Duration::from_secs(3));
+    group.sample_size(10);
+    group.sampling_mode(criterion::SamplingMode::Flat);
     for (label, ratio) in overlap_cases {
         let (set_a, set_b) = two_sets_with_overlap(SET_SIZE, ratio);
         let total = (set_a.len() + set_b.len()) as u64;

--- a/benches/algebra.rs
+++ b/benches/algebra.rs
@@ -1,0 +1,205 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use gzset::{FastHashMap, ScoreSet};
+
+mod support;
+
+const SET_SIZE: usize = 120_000;
+
+fn bench_algebra(c: &mut Criterion) {
+    let overlap_cases = [
+        ("0pct", 0.0),
+        ("25pct", 0.25),
+        ("50pct", 0.5),
+        ("90pct", 0.9),
+    ];
+
+    let mut group = c.benchmark_group("algebra");
+    for (label, ratio) in overlap_cases {
+        let (set_a, set_b) = two_sets_with_overlap(SET_SIZE, ratio);
+        let total = (set_a.len() + set_b.len()) as u64;
+        group.throughput(Throughput::Elements(total));
+        group.bench_function(format!("union/2sets/{label}"), |b| {
+            b.iter(|| {
+                let cardinality = union_two(set_a, set_b);
+                black_box(cardinality);
+            });
+        });
+        group.bench_function(format!("inter/2sets/{label}"), |b| {
+            b.iter(|| {
+                let cardinality = inter_two(set_a, set_b);
+                black_box(cardinality);
+            });
+        });
+        group.bench_function(format!("diff/2sets/{label}"), |b| {
+            b.iter(|| {
+                let cardinality = diff_two(set_a, set_b);
+                black_box(cardinality);
+            });
+        });
+        group.bench_function(format!("intercard/2sets/{label}"), |b| {
+            b.iter(|| {
+                let cardinality = intercard_two(set_a, set_b, None);
+                black_box(cardinality);
+            });
+        });
+        let limit = set_a.len() / 5;
+        group.bench_function(format!("intercard/2sets/{label}/limit"), |b| {
+            b.iter(|| {
+                let cardinality = intercard_two(set_a, set_b, Some(limit));
+                black_box(cardinality);
+            });
+        });
+    }
+
+    let multi_sets = multi_set_family();
+    group.throughput(Throughput::Elements(
+        multi_sets.iter().map(|s| s.len() as u64).sum(),
+    ));
+    group.bench_function("union/multikey/6sets", |b| {
+        b.iter(|| {
+            let cardinality = union_multi(&multi_sets);
+            black_box(cardinality);
+        });
+    });
+    group.bench_function("inter/multikey/6sets", |b| {
+        b.iter(|| {
+            let cardinality = inter_multi(&multi_sets);
+            black_box(cardinality);
+        });
+    });
+
+    group.finish();
+}
+
+fn two_sets_with_overlap(size: usize, ratio: f64) -> (&'static ScoreSet, &'static ScoreSet) {
+    let entries_a = support::unique_increasing(size);
+    let overlap = ((size as f64) * ratio).round() as usize;
+    let mut entries_b = Vec::with_capacity(size);
+    for (score, member) in entries_a.iter().take(overlap) {
+        entries_b.push((score + 0.5, member.clone()));
+    }
+    let mut extra_idx = 0usize;
+    let mut next_score = size as f64;
+    while entries_b.len() < size {
+        entries_b.push((
+            next_score + extra_idx as f64,
+            format!("b_extra:{ratio:.2}:{extra_idx}"),
+        ));
+        extra_idx += 1;
+    }
+    let set_a = Box::leak(Box::new(support::build_set(&entries_a)));
+    let set_b = Box::leak(Box::new(support::build_set(&entries_b)));
+    (set_a, set_b)
+}
+
+fn multi_set_family() -> Vec<&'static ScoreSet> {
+    let configs = [
+        ("uniform", 40_000usize),
+        ("cluster", 60_000usize),
+        ("zipf", 80_000usize),
+        ("uniform", 20_000usize),
+        ("cluster", 50_000usize),
+        ("zipf", 30_000usize),
+    ];
+    configs
+        .iter()
+        .map(|(kind, size)| {
+            let entries = match *kind {
+                "uniform" => support::uniform_random(*size, *size as f64),
+                "cluster" => support::clustered(*size, 8, 4.0),
+                "zipf" => support::zipf_like(*size, 1.3),
+                _ => unreachable!(),
+            };
+            Box::leak(Box::new(support::build_set(&entries)))
+        })
+        .collect()
+}
+
+fn union_two(a: &ScoreSet, b: &ScoreSet) -> usize {
+    let mut agg: FastHashMap<String, f64> = FastHashMap::default();
+    agg.reserve(a.len() + b.len());
+    for (member, score) in a.iter_all() {
+        agg.insert(member.to_owned(), score);
+    }
+    for (member, score) in b.iter_all() {
+        agg.entry(member.to_owned())
+            .and_modify(|v| *v += score)
+            .or_insert(score);
+    }
+    agg.len()
+}
+
+fn inter_two(a: &ScoreSet, b: &ScoreSet) -> usize {
+    let (small, big) = if a.len() <= b.len() { (a, b) } else { (b, a) };
+    let mut count = 0usize;
+    for (member, _) in small.iter_all() {
+        if big.contains(member) {
+            count += 1;
+        }
+    }
+    count
+}
+
+fn diff_two(a: &ScoreSet, b: &ScoreSet) -> usize {
+    let mut count = 0usize;
+    for (member, _) in a.iter_all() {
+        if !b.contains(member) {
+            count += 1;
+        }
+    }
+    count
+}
+
+fn intercard_two(a: &ScoreSet, b: &ScoreSet, limit: Option<usize>) -> usize {
+    let (small, big) = if a.len() <= b.len() { (a, b) } else { (b, a) };
+    let mut count = 0usize;
+    for (member, _) in small.iter_all() {
+        if big.contains(member) {
+            count += 1;
+            if let Some(limit) = limit {
+                if count >= limit {
+                    break;
+                }
+            }
+        }
+    }
+    count
+}
+
+fn union_multi(sets: &[&ScoreSet]) -> usize {
+    let mut agg: FastHashMap<String, f64> = FastHashMap::default();
+    for set in sets {
+        agg.reserve(set.len());
+        for (member, score) in set.iter_all() {
+            agg.entry(member.to_owned())
+                .and_modify(|v| *v += score)
+                .or_insert(score);
+        }
+    }
+    agg.len()
+}
+
+fn inter_multi(sets: &[&ScoreSet]) -> usize {
+    let mut iter = sets.iter();
+    let Some(first) = iter.next() else { return 0 };
+    let mut acc: FastHashMap<String, f64> = FastHashMap::default();
+    for (member, score) in first.iter_all() {
+        acc.insert(member.to_owned(), score);
+    }
+    for set in iter {
+        acc.retain(|member, total| match set.score(member) {
+            Some(score) => {
+                *total += score;
+                true
+            }
+            None => false,
+        });
+        if acc.is_empty() {
+            break;
+        }
+    }
+    acc.len()
+}
+
+criterion_group!(benches, bench_algebra);
+criterion_main!(benches);

--- a/benches/gzadd.rs
+++ b/benches/gzadd.rs
@@ -1,0 +1,105 @@
+use criterion::{
+    black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput,
+};
+use rand::{seq::SliceRandom, Rng};
+
+mod support;
+
+const INSERT_SIZE: usize = 200_000;
+const UPDATE_SIZE: usize = 150_000;
+const UPDATE_TOUCH: usize = 25_000;
+
+fn bench_insert(c: &mut Criterion) {
+    let unique_entries = support::unique_increasing(INSERT_SIZE);
+    let uniform_entries = support::uniform_random(INSERT_SIZE, INSERT_SIZE as f64);
+    let high_ties_entries = build_high_ties(INSERT_SIZE);
+
+    let mut group = c.benchmark_group("insert");
+    for (name, entries) in [
+        ("unique_increasing", &unique_entries),
+        ("uniform_random", &uniform_entries),
+        ("high_ties", &high_ties_entries),
+    ] {
+        let dataset = BenchmarkId::new("insert", name);
+        group.throughput(Throughput::Elements(entries.len() as u64));
+        group.bench_with_input(dataset, entries, |b, data| {
+            b.iter(|| {
+                let mut set = support::build_set(data);
+                black_box(set.len());
+            });
+        });
+        let built = support::build_set(entries);
+        let mem = support::mem_usage_bytes(&built);
+        support::record_memory_csv("insert", name, mem);
+    }
+    group.finish();
+}
+
+fn bench_update(c: &mut Criterion) {
+    let base_entries = support::uniform_random(UPDATE_SIZE, UPDATE_SIZE as f64);
+    let mut rng = support::seeded_rng();
+    let mut indices: Vec<usize> = (0..base_entries.len()).collect();
+    indices.shuffle(&mut rng);
+    let touch = UPDATE_TOUCH.min(base_entries.len());
+    let mut nearby_updates = Vec::with_capacity(touch);
+    let mut far_updates = Vec::with_capacity(touch);
+    for &idx in indices.iter().take(touch) {
+        let (score, member) = &base_entries[idx];
+        let mut delta = rng.gen_range(-0.25..=0.25);
+        if delta == 0.0 {
+            delta = 0.125;
+        }
+        nearby_updates.push((member.clone(), score + delta));
+        let far_target = rng.gen_range(0.0..(UPDATE_SIZE as f64 * 10.0));
+        far_updates.push((member.clone(), far_target));
+    }
+
+    let mut group = c.benchmark_group("update");
+    group.throughput(Throughput::Elements(nearby_updates.len() as u64));
+    group.bench_function("score_move_nearby", |b| {
+        b.iter_batched(
+            || support::build_set(&base_entries),
+            |mut set| {
+                for (member, score) in &nearby_updates {
+                    set.insert(*score, member);
+                }
+                black_box(set.len());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.throughput(Throughput::Elements(far_updates.len() as u64));
+    group.bench_function("score_move_far", |b| {
+        b.iter_batched(
+            || support::build_set(&base_entries),
+            |mut set| {
+                for (member, score) in &far_updates {
+                    set.insert(*score, member);
+                }
+                black_box(set.len());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+fn build_high_ties(target: usize) -> Vec<(f64, String)> {
+    let mut rng = support::seeded_rng();
+    let mut entries = Vec::with_capacity(target);
+    let mut score = 0.0;
+    while entries.len() < target {
+        let ties = rng.gen_range(1_000..=4_000);
+        for local in 0..ties {
+            if entries.len() == target {
+                break;
+            }
+            entries.push((score, format!("tie:{score}:{local}")));
+        }
+        score += 1.0;
+    }
+    entries
+}
+
+criterion_group!(benches, bench_insert, bench_update);
+criterion_main!(benches);

--- a/benches/gzrand.rs
+++ b/benches/gzrand.rs
@@ -1,0 +1,87 @@
+use std::cell::RefCell;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use rand::{seq::index::sample, Rng};
+use rustc_hash::FxHashSet;
+
+mod support;
+
+const RAND_SIZE: usize = 200_000;
+const COUNT_SMALL: usize = 64;
+
+fn bench_randmember(c: &mut Criterion) {
+    let entries = support::zipf_like(RAND_SIZE, 1.2);
+    let set = Box::leak(Box::new(support::build_set(&entries)));
+    let len = set.len();
+
+    let mut group = c.benchmark_group("randmember");
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("single/no_scores", |b| {
+        let rng = RefCell::new(support::seeded_rng());
+        b.iter(|| {
+            let idx = rng.borrow_mut().gen_range(0..len);
+            let (member, _) = set.select_by_rank(idx);
+            black_box(member);
+        });
+    });
+    group.bench_function("single/with_scores", |b| {
+        let rng = RefCell::new(support::seeded_rng());
+        b.iter(|| {
+            let idx = rng.borrow_mut().gen_range(0..len);
+            let (member, score) = set.select_by_rank(idx);
+            black_box((member, score));
+        });
+    });
+
+    let count_large = (len / 10).max(COUNT_SMALL);
+    group.throughput(Throughput::Elements(COUNT_SMALL as u64));
+    group.bench_function("count_pos_small", |b| {
+        let rng = RefCell::new(support::seeded_rng());
+        b.iter(|| {
+            let mut seen: FxHashSet<usize> = FxHashSet::default();
+            let mut taken = Vec::with_capacity(COUNT_SMALL);
+            let mut guard = rng.borrow_mut();
+            while taken.len() < COUNT_SMALL {
+                let idx = guard.gen_range(0..len);
+                if seen.insert(idx) {
+                    taken.push(set.select_by_rank(idx));
+                }
+            }
+            black_box(taken.len());
+        });
+    });
+
+    group.throughput(Throughput::Elements(count_large as u64));
+    group.bench_function("count_pos_large", |b| {
+        let rng = RefCell::new(support::seeded_rng());
+        b.iter(|| {
+            let sample = sample(&mut rng.borrow_mut(), len, count_large).into_vec();
+            let mut indices = sample.clone();
+            indices.sort_unstable();
+            let mut results = Vec::with_capacity(indices.len());
+            for idx in indices {
+                results.push(set.select_by_rank(idx));
+            }
+            black_box(results.len());
+        });
+    });
+
+    group.throughput(Throughput::Elements(count_large as u64));
+    group.bench_function("count_neg_with_replacement", |b| {
+        let rng = RefCell::new(support::seeded_rng());
+        b.iter(|| {
+            let mut out = Vec::with_capacity(count_large);
+            let mut guard = rng.borrow_mut();
+            for _ in 0..count_large {
+                let idx = guard.gen_range(0..len);
+                out.push(set.select_by_rank(idx));
+            }
+            black_box(out.len());
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_randmember);
+criterion_main!(benches);

--- a/benches/gzrange.rs
+++ b/benches/gzrange.rs
@@ -1,85 +1,73 @@
 use std::time::Duration;
 
-use criterion::{criterion_group, criterion_main, Criterion, SamplingMode, Throughput};
+use criterion::{
+    black_box, criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode, Throughput,
+};
 use gzset::ScoreSet;
-use ordered_float::OrderedFloat;
+
+mod support;
+
+const RANGE_SIZE: usize = 500_000;
 
 fn bench_range(c: &mut Criterion) {
-    let entries: Vec<(f64, String)> = (0..1_000_000).map(|i| (i as f64, i.to_string())).collect();
+    let datasets = [
+        ("unique_increasing", support::unique_increasing(RANGE_SIZE)),
+        ("same_score", support::same_score(RANGE_SIZE, 42.0)),
+    ];
+
     let mut group = c.benchmark_group("gzrange_iter");
     group.measurement_time(Duration::from_secs(12));
     group.warm_up_time(Duration::from_secs(3));
     group.sample_size(10);
     group.sampling_mode(SamplingMode::Flat);
 
-    group.throughput(Throughput::Elements(entries.len() as u64));
-    group.bench_function("iter", |b| {
-        b.iter(|| {
-            let mut set = ScoreSet::default();
-            for (s, m) in &entries {
-                set.insert(*s, m);
-            }
-            let mut iter = set.iter_range_fwd(0, entries.len() as isize - 1);
-            for _ in &mut iter {}
-        })
-    });
-    let tail_len = entries.len() - (entries.len() * 9 / 10);
-
-    group.throughput(Throughput::Elements(tail_len as u64));
-    group.bench_function("iter_from_90pct", |b| {
-        b.iter(|| {
-            let mut set = ScoreSet::default();
-            for (s, m) in &entries {
-                set.insert(*s, m);
-            }
-            let start_idx = entries.len() * 9 / 10;
-            let start_score = OrderedFloat(entries[start_idx].0);
-            let member = entries[start_idx].1.as_str();
-            let mut iter = set.iter_from(start_score, member, false);
-            for _ in &mut iter {}
-        })
-    });
-    group.throughput(Throughput::Elements(tail_len as u64));
-    group.bench_function("iter_from_90pct_hot", |b| {
-        let mut set = ScoreSet::default();
-        for (s, m) in &entries {
-            set.insert(*s, m);
-        }
-        let start_idx = entries.len() * 9 / 10;
-        let start_score = OrderedFloat(entries[start_idx].0);
-        let member = entries[start_idx].1.as_str();
-        b.iter(|| {
-            let mut iter = set.iter_from(start_score, member, false);
-            for _ in &mut iter {}
-        })
-    });
-    group.throughput(Throughput::Elements(tail_len as u64));
-    group.bench_function("iter_from_gap_90pct", |b| {
-        b.iter(|| {
-            let mut set = ScoreSet::default();
-            for (s, m) in &entries {
-                set.insert(*s, m);
-            }
-            let start_idx = entries.len() * 9 / 10;
-            let start_score = OrderedFloat(entries[start_idx].0 + 0.5);
-            let mut iter = set.iter_from(start_score, "", false);
-            for _ in &mut iter {}
-        })
-    });
-    group.throughput(Throughput::Elements(tail_len as u64));
-    group.bench_function("iter_from_gap_90pct_hot", |b| {
-        let mut set = ScoreSet::default();
-        for (s, m) in &entries {
-            set.insert(*s, m);
-        }
-        let start_idx = entries.len() * 9 / 10;
-        let start_score = OrderedFloat(entries[start_idx].0 + 0.5);
-        b.iter(|| {
-            let mut iter = set.iter_from(start_score, "", false);
-            for _ in &mut iter {}
-        })
-    });
+    for (name, entries) in datasets {
+        let set = Box::leak(Box::new(support::build_set(&entries)));
+        add_range_benches(&mut group, name, set);
+    }
     group.finish();
+}
+
+fn add_range_benches(
+    group: &mut criterion::BenchmarkGroup<'_, Criterion>,
+    name: &str,
+    set: &ScoreSet,
+) {
+    let len = set.len() as isize;
+    let window_1k = 1_000;
+    let window_10k = 10_000;
+    let mid_start = len / 2 - (window_10k as isize / 2);
+    let window_start = mid_start.max(0);
+
+    group.throughput(Throughput::Elements(window_1k as u64));
+    group.bench_function(BenchmarkId::new("iter/window_1k", name), |b| {
+        b.iter(|| {
+            let mut iter = set.iter_range_fwd(window_start, window_start + window_1k as isize - 1);
+            for item in &mut iter {
+                black_box(item);
+            }
+        });
+    });
+
+    group.throughput(Throughput::Elements(window_10k as u64));
+    group.bench_function(BenchmarkId::new("iter/window_10k", name), |b| {
+        b.iter(|| {
+            let mut iter = set.iter_range_fwd(window_start, window_start + window_10k as isize - 1);
+            for item in &mut iter {
+                black_box(item);
+            }
+        });
+    });
+
+    group.throughput(Throughput::Elements(set.len() as u64));
+    group.bench_function(BenchmarkId::new("iter/whole_set", name), |b| {
+        b.iter(|| {
+            let mut iter = set.iter_range_fwd(0, len - 1);
+            for item in &mut iter {
+                black_box(item);
+            }
+        });
+    });
 }
 
 criterion_group!(benches, bench_range);

--- a/benches/gzrange.rs
+++ b/benches/gzrange.rs
@@ -7,16 +7,15 @@ use gzset::ScoreSet;
 
 mod support;
 
-const RANGE_SIZE: usize = 500_000;
-
 fn bench_range(c: &mut Criterion) {
+    let range_size = support::usize_env("GZSET_BENCH_RANGE_SIZE", 500_000);
     let datasets = [
-        ("unique_increasing", support::unique_increasing(RANGE_SIZE)),
-        ("same_score", support::same_score(RANGE_SIZE, 42.0)),
+        ("unique_increasing", support::unique_increasing(range_size)),
+        ("same_score", support::same_score(range_size, 42.0)),
     ];
 
     let mut group = c.benchmark_group("gzrange_iter");
-    group.measurement_time(Duration::from_secs(12));
+    group.measurement_time(Duration::from_secs(10));
     group.warm_up_time(Duration::from_secs(3));
     group.sample_size(10);
     group.sampling_mode(SamplingMode::Flat);

--- a/benches/gzrem.rs
+++ b/benches/gzrem.rs
@@ -1,0 +1,95 @@
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+
+mod support;
+
+const REMOVE_SIZE: usize = 150_000;
+const REMOVE_COUNT: usize = 25_000;
+
+fn bench_remove(c: &mut Criterion) {
+    let base_entries = support::unique_increasing(REMOVE_SIZE);
+    let mut shuffled_members: Vec<String> = base_entries
+        .iter()
+        .map(|(_, member)| member.clone())
+        .collect();
+    support::shuffle_members(&mut shuffled_members);
+    let random_targets = shuffled_members[..REMOVE_COUNT.min(shuffled_members.len())].to_vec();
+    let front_targets: Vec<String> = base_entries
+        .iter()
+        .take(REMOVE_COUNT)
+        .map(|(_, m)| m.clone())
+        .collect();
+    let back_targets: Vec<String> = base_entries
+        .iter()
+        .rev()
+        .take(REMOVE_COUNT)
+        .map(|(_, m)| m.clone())
+        .collect();
+
+    record_remove_delta("random_existing", &base_entries, &random_targets);
+    record_remove_delta("cluster_front", &base_entries, &front_targets);
+    record_remove_delta("cluster_back", &base_entries, &back_targets);
+
+    let mut group = c.benchmark_group("remove");
+    group.throughput(Throughput::Elements(random_targets.len() as u64));
+    group.bench_function("random_existing", |b| {
+        b.iter_batched(
+            || support::build_set(&base_entries),
+            |mut set| {
+                let before = support::mem_usage_bytes(&set);
+                for member in &random_targets {
+                    let removed = set.remove(member);
+                    black_box(removed);
+                }
+                let after = support::mem_usage_bytes(&set);
+                black_box(before.saturating_sub(after));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.throughput(Throughput::Elements(front_targets.len() as u64));
+    group.bench_function("cluster_front", |b| {
+        b.iter_batched(
+            || support::build_set(&base_entries),
+            |mut set| {
+                let before = support::mem_usage_bytes(&set);
+                for member in &front_targets {
+                    let removed = set.remove(member);
+                    black_box(removed);
+                }
+                let after = support::mem_usage_bytes(&set);
+                black_box(before.saturating_sub(after));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.throughput(Throughput::Elements(back_targets.len() as u64));
+    group.bench_function("cluster_back", |b| {
+        b.iter_batched(
+            || support::build_set(&base_entries),
+            |mut set| {
+                let before = support::mem_usage_bytes(&set);
+                for member in &back_targets {
+                    let removed = set.remove(member);
+                    black_box(removed);
+                }
+                let after = support::mem_usage_bytes(&set);
+                black_box(before.saturating_sub(after));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+fn record_remove_delta(name: &str, entries: &[(f64, String)], removals: &[String]) {
+    let mut set = support::build_set(entries);
+    let before = support::mem_usage_bytes(&set);
+    for member in removals {
+        let _ = set.remove(member);
+    }
+    let after = support::mem_usage_bytes(&set);
+    support::record_memory_csv("remove", name, before.saturating_sub(after));
+}
+
+criterion_group!(benches, bench_remove);
+criterion_main!(benches);

--- a/benches/gzscan.rs
+++ b/benches/gzscan.rs
@@ -1,0 +1,147 @@
+use std::cell::RefCell;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use gzset::{fmt_f64, with_fmt_buf, ScoreSet};
+use ordered_float::OrderedFloat;
+use rand::Rng;
+
+mod support;
+
+const SCAN_SIZE: usize = 150_000;
+const CURSOR_SAMPLES: usize = 256;
+
+fn bench_scan(c: &mut Criterion) {
+    let entries = build_scan_entries(SCAN_SIZE);
+    let set = Box::leak(Box::new(support::build_set(&entries)));
+    let cursors = build_cursors(set);
+
+    let mut group = c.benchmark_group("scan");
+    for &count in &[10usize, 100, 1024] {
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_function(format!("count_{count}"), |b| {
+            let index = RefCell::new(0usize);
+            b.iter(|| {
+                let mut guard = index.borrow_mut();
+                let cursor = &cursors[*guard];
+                let next = simulate_scan(set, cursor, count);
+                *guard = (*guard + 1) % cursors.len();
+                black_box(next);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn build_scan_entries(n: usize) -> Vec<(f64, String)> {
+    (0..n)
+        .map(|i| {
+            let score = i as f64 * 0.5;
+            let member = format!("name|{:04X}%{:02X}", i, i % 97);
+            (score, member)
+        })
+        .collect()
+}
+
+fn build_cursors(set: &ScoreSet) -> Vec<String> {
+    let mut cursors = Vec::with_capacity(CURSOR_SAMPLES + 1);
+    cursors.push("0".to_string());
+    let members = set.members_with_scores();
+    let mut rng = support::seeded_rng();
+    for _ in 0..CURSOR_SAMPLES {
+        let idx = rng.gen_range(0..members.len());
+        let (member, score) = &members[idx];
+        cursors.push(encode_cursor(*score, member));
+    }
+    cursors
+}
+
+fn simulate_scan(set: &ScoreSet, cursor: &str, count: usize) -> String {
+    let parsed = if cursor == "0" {
+        None
+    } else {
+        Some(decode_cursor(cursor).expect("valid cursor"))
+    };
+    let mut iter = match parsed {
+        None => set
+            .iter_from(OrderedFloat(f64::NEG_INFINITY), "", true)
+            .peekable(),
+        Some((score, ref member)) => set.iter_from(OrderedFloat(score), member, true).peekable(),
+    };
+
+    let mut arr = Vec::with_capacity(count * 2);
+    let mut last = None;
+    for _ in 0..count {
+        if let Some((m, sc)) = iter.next() {
+            arr.push(m.to_owned());
+            with_fmt_buf(|b| arr.push(fmt_f64(b, sc).to_owned()));
+            last = Some((sc, m.to_owned()));
+        } else {
+            break;
+        }
+    }
+    black_box(&arr);
+    match last {
+        Some((sc, m)) if iter.peek().is_some() => encode_cursor(sc, &m),
+        _ => "0".to_string(),
+    }
+}
+
+fn encode_cursor(score: f64, member: &str) -> String {
+    with_fmt_buf(|b| {
+        let score_s = fmt_f64(b, score);
+        let mut out = String::with_capacity(score_s.len() + 1 + member.len() * 3);
+        out.push_str(score_s);
+        out.push('|');
+        for ch in member.chars() {
+            match ch {
+                '|' => out.push_str("%7C"),
+                '%' => out.push_str("%25"),
+                _ => out.push(ch),
+            }
+        }
+        out
+    })
+}
+
+fn decode_cursor(cur: &str) -> Option<(f64, String)> {
+    let (score_s, member_s) = cur.split_once('|')?;
+    let score = score_s.parse::<f64>().ok()?;
+    if !score.is_finite() {
+        return None;
+    }
+    if !with_fmt_buf(|b| fmt_f64(b, score) == score_s) {
+        return None;
+    }
+
+    fn decode_hex(b: u8) -> Option<u8> {
+        match b {
+            b'0'..=b'9' => Some(b - b'0'),
+            b'a'..=b'f' => Some(b - b'a' + 10),
+            b'A'..=b'F' => Some(b - b'A' + 10),
+            _ => None,
+        }
+    }
+
+    let bytes = member_s.as_bytes();
+    let mut member_bytes = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            if i + 2 >= bytes.len() {
+                return None;
+            }
+            let hi = decode_hex(bytes[i + 1])?;
+            let lo = decode_hex(bytes[i + 2])?;
+            member_bytes.push((hi << 4) | lo);
+            i += 3;
+        } else {
+            member_bytes.push(bytes[i]);
+            i += 1;
+        }
+    }
+    let member = String::from_utf8(member_bytes).ok()?;
+    Some((score, member))
+}
+
+criterion_group!(benches, bench_scan);
+criterion_main!(benches);

--- a/benches/lookup.rs
+++ b/benches/lookup.rs
@@ -1,0 +1,57 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+
+mod support;
+
+const LOOKUP_SIZE: usize = 200_000;
+const QUERY_COUNT: usize = 50_000;
+
+fn bench_lookup(c: &mut Criterion) {
+    let entries = support::uniform_random(LOOKUP_SIZE, LOOKUP_SIZE as f64);
+    let set = Box::leak(Box::new(support::build_set(&entries)));
+    let existing = support::pick_existing(set, QUERY_COUNT);
+    let missing: Vec<String> = (0..existing.len())
+        .map(|i| format!("missing:{i}"))
+        .collect();
+
+    let mut group = c.benchmark_group("lookup");
+    group.throughput(Throughput::Elements(existing.len() as u64));
+    group.bench_function("rank/existing_random", |b| {
+        b.iter(|| {
+            for member in &existing {
+                let res = set.rank(black_box(member.as_str()));
+                black_box(res);
+            }
+        });
+    });
+    group.throughput(Throughput::Elements(missing.len() as u64));
+    group.bench_function("rank/missing_random", |b| {
+        b.iter(|| {
+            for member in &missing {
+                let res = set.rank(black_box(member.as_str()));
+                black_box(res);
+            }
+        });
+    });
+    group.throughput(Throughput::Elements(existing.len() as u64));
+    group.bench_function("score/existing_random", |b| {
+        b.iter(|| {
+            for member in &existing {
+                let res = set.score(black_box(member.as_str()));
+                black_box(res);
+            }
+        });
+    });
+    group.throughput(Throughput::Elements(missing.len() as u64));
+    group.bench_function("score/missing_random", |b| {
+        b.iter(|| {
+            for member in &missing {
+                let res = set.score(black_box(member.as_str()));
+                black_box(res);
+            }
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_lookup);
+criterion_main!(benches);

--- a/benches/lookup.rs
+++ b/benches/lookup.rs
@@ -1,19 +1,23 @@
+use std::time::Duration;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 
 mod support;
 
-const LOOKUP_SIZE: usize = 200_000;
-const QUERY_COUNT: usize = 50_000;
-
 fn bench_lookup(c: &mut Criterion) {
-    let entries = support::uniform_random(LOOKUP_SIZE, LOOKUP_SIZE as f64);
+    let lookup_size = support::usize_env("GZSET_BENCH_LOOKUP_SIZE", 200_000);
+    let query_count = support::usize_env("GZSET_BENCH_QUERY_COUNT", 50_000);
+    let entries = support::uniform_random(lookup_size, lookup_size as f64);
     let set = Box::leak(Box::new(support::build_set(&entries)));
-    let existing = support::pick_existing(set, QUERY_COUNT);
+    let existing = support::pick_existing(set, query_count);
     let missing: Vec<String> = (0..existing.len())
         .map(|i| format!("missing:{i}"))
         .collect();
 
     let mut group = c.benchmark_group("lookup");
+    group.measurement_time(Duration::from_secs(10));
+    group.warm_up_time(Duration::from_secs(3));
+    group.sample_size(10);
     group.throughput(Throughput::Elements(existing.len() as u64));
     group.bench_function("rank/existing_random", |b| {
         b.iter(|| {

--- a/benches/support/mod.rs
+++ b/benches/support/mod.rs
@@ -1,0 +1,138 @@
+use std::{
+    fs::{create_dir_all, OpenOptions},
+    io::{BufWriter, Write},
+    os::raw::c_void,
+    path::Path,
+    sync::Mutex,
+};
+
+use gzset::ScoreSet;
+use once_cell::sync::Lazy;
+use rand::{rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
+
+static BASE_SEED: Lazy<u64> = Lazy::new(|| {
+    std::env::var("GZSET_BENCH_SEED")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(0x7d11_5eed_f065_cafe)
+});
+
+static RNG_COUNTER: Lazy<Mutex<u64>> = Lazy::new(|| Mutex::new(0));
+
+static CSV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+extern "C" {
+    fn gzset_mem_usage(value: *const c_void) -> usize;
+}
+
+#[inline]
+pub fn seeded_rng() -> StdRng {
+    let mut guard = RNG_COUNTER.lock().unwrap();
+    let seed = BASE_SEED.wrapping_add(*guard);
+    *guard = guard.wrapping_add(1);
+    StdRng::seed_from_u64(seed)
+}
+
+pub fn unique_increasing(n: usize) -> Vec<(f64, String)> {
+    (0..n).map(|i| (i as f64, format!("member:{i}"))).collect()
+}
+
+pub fn uniform_random(n: usize, score_range: f64) -> Vec<(f64, String)> {
+    let mut rng = seeded_rng();
+    (0..n)
+        .map(|i| (rng.gen_range(0.0..score_range), format!("rand:{i}")))
+        .collect()
+}
+
+pub fn same_score(n: usize, score: f64) -> Vec<(f64, String)> {
+    (0..n).map(|i| (score, format!("same:{i}"))).collect()
+}
+
+pub fn clustered(n: usize, clusters: usize, spread: f64) -> Vec<(f64, String)> {
+    assert!(clusters > 0, "clusters must be > 0");
+    let mut rng = seeded_rng();
+    let mut out = Vec::with_capacity(n);
+    let mut generated = 0usize;
+    let base_gap = spread.max(1.0);
+    for cluster_idx in 0..clusters {
+        if generated >= n {
+            break;
+        }
+        let remaining = n - generated;
+        let clusters_left = clusters - cluster_idx;
+        let target = (remaining + clusters_left - 1) / clusters_left;
+        let center = cluster_idx as f64 * base_gap * 10.0;
+        for local in 0..target {
+            let delta = rng.gen_range(-spread..=spread);
+            let score = center + delta;
+            out.push((score, format!("cluster:{cluster_idx}:{local}")));
+        }
+        generated += target;
+    }
+    out
+}
+
+pub fn zipf_like(n: usize, s: f64) -> Vec<(f64, String)> {
+    let exponent = s.max(0.5);
+    (0..n)
+        .map(|i| {
+            let rank = (i + 1) as f64;
+            let score = rank.powf(exponent);
+            (score, format!("zipf:{i}"))
+        })
+        .collect()
+}
+
+pub fn build_set(entries: &[(f64, String)]) -> ScoreSet {
+    let mut set = ScoreSet::default();
+    for (score, member) in entries {
+        set.insert(*score, member);
+    }
+    set
+}
+
+pub fn shuffle_members(members: &mut [String]) {
+    let mut rng = seeded_rng();
+    members.shuffle(&mut rng);
+}
+
+pub fn pick_existing(set: &ScoreSet, k: usize) -> Vec<String> {
+    let mut rng = seeded_rng();
+    let mut names = set.member_names();
+    names.shuffle(&mut rng);
+    names.truncate(names.len().min(k));
+    names
+}
+
+pub fn mem_usage_bytes(set: &ScoreSet) -> usize {
+    unsafe { gzset_mem_usage(set as *const _ as *const c_void) }
+}
+
+pub fn record_memory_csv(group: &str, dataset: &str, bytes: usize) {
+    record_csv_row("memory_metrics.csv", group, dataset, bytes);
+}
+
+fn record_csv_row(file_name: &str, group: &str, dataset: &str, bytes: usize) {
+    let _guard = CSV_LOCK.lock().unwrap();
+    let base = Path::new("target/criterion");
+    if let Err(err) = create_dir_all(base) {
+        eprintln!("failed to create metric directory: {err}");
+        return;
+    }
+    let path = base.join(file_name);
+    let exists = path.exists();
+    let file = match OpenOptions::new().create(true).append(true).open(&path) {
+        Ok(file) => file,
+        Err(err) => {
+            eprintln!("failed to open metric csv {path:?}: {err}");
+            return;
+        }
+    };
+    let mut writer = BufWriter::new(file);
+    if !exists {
+        let _ = writeln!(writer, "group,dataset,bytes");
+    }
+    if let Err(err) = writeln!(writer, "{group},{dataset},{bytes}") {
+        eprintln!("failed to record metric row: {err}");
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared `benches::support` module for dataset generation, deterministic RNG, and memory metric logging used across benches
- introduce micro-bench coverage for insert/update/remove, lookup, range, randmember, algebra, and scan operations built on the new harness
- register the new Criterion bench targets in `Cargo.toml`

## Testing
- cargo build --all-targets
- cargo test
- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args


------
https://chatgpt.com/codex/tasks/task_e_68d6edb59ea08326a095d05f4c1a7be6