### PR TITLE
Add memory tracking to benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,11 @@ name = "gzscan"
 harness = false
 required-features = ["bench"]
 
+[[bench]]
+name = "memory"
+harness = false
+required-features = ["bench"]
+
 [dependencies]
 redis-module = "2.0.7"
 once_cell = "1"

--- a/benches/gzadd.rs
+++ b/benches/gzadd.rs
@@ -32,7 +32,7 @@ fn bench_insert(c: &mut Criterion) {
         });
         let built = support::build_set(entries);
         let mem = support::mem_usage_bytes(&built);
-        support::record_memory_csv("insert", name, mem);
+        support::record_mem(format!("insert/{name}"), mem);
     }
     group.finish();
 }

--- a/benches/gzadd_tied.rs
+++ b/benches/gzadd_tied.rs
@@ -1,6 +1,8 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use gzset::ScoreSet;
 
+mod support;
+
 fn bench_insert_many_ties(c: &mut Criterion) {
     let entries: Vec<(f64, String)> = (0..200_000)
         .map(|i| ((i % 1_024) as f64, format!("member:{i}")))
@@ -18,6 +20,10 @@ fn bench_insert_many_ties(c: &mut Criterion) {
         })
     });
     group.finish();
+
+    let built = support::build_set(&entries);
+    let mem = support::mem_usage_bytes(&built);
+    support::record_mem("insert_many_ties", mem);
 }
 
 criterion_group!(benches, bench_insert_many_ties);

--- a/benches/gzrem.rs
+++ b/benches/gzrem.rs
@@ -92,7 +92,7 @@ fn record_remove_delta(name: &str, entries: &[(f64, String)], removals: &[String
         let _ = set.remove(member);
     }
     let after = support::mem_usage_bytes(&set);
-    support::record_memory_csv("remove", name, before.saturating_sub(after));
+    support::record_mem(format!("remove/{name}"), before.saturating_sub(after));
 }
 
 criterion_group!(benches, bench_remove);

--- a/benches/memory.rs
+++ b/benches/memory.rs
@@ -1,0 +1,34 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+mod support;
+
+fn bench_memory(_: &mut Criterion) {
+    const SIZES: [usize; 5] = [10_000, 50_000, 100_000, 500_000, 1_000_000];
+    let datasets: [(&str, fn(usize) -> Vec<(f64, String)>); 3] = [
+        ("unique_increasing", support::unique_increasing),
+        ("same_score", same_score_dataset),
+        ("uniform_random", uniform_random_dataset),
+    ];
+
+    for &(name, generator) in &datasets {
+        for &n in &SIZES {
+            let entries = generator(n);
+            let set = support::build_set(&entries);
+            let total_bytes = support::mem_usage_bytes(&set);
+            let bench_id = format!("memory/{name}/{n}");
+            support::record_mem(bench_id.as_str(), total_bytes);
+            support::record_structural_mem(bench_id.as_str(), set.mem_bytes());
+        }
+    }
+}
+
+fn same_score_dataset(n: usize) -> Vec<(f64, String)> {
+    support::same_score(n, 42.0)
+}
+
+fn uniform_random_dataset(n: usize) -> Vec<(f64, String)> {
+    support::uniform_random(n, n as f64)
+}
+
+criterion_group!(benches, bench_memory);
+criterion_main!(benches);

--- a/benches/support/mem.rs
+++ b/benches/support/mem.rs
@@ -1,0 +1,54 @@
+use std::{
+    fmt::Display,
+    fs::{create_dir_all, OpenOptions},
+    io::{BufWriter, Write},
+    path::Path,
+    sync::Mutex,
+};
+
+use once_cell::sync::Lazy;
+
+static LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+const BASE_DIR: &str = "target/bench-mem";
+const MEMORY_FILE: &str = "memory.csv";
+const STRUCTURAL_FILE: &str = "memory_structural.csv";
+
+pub fn record_mem<K: Display>(bench_id: K, bytes: usize) {
+    record_line(MEMORY_FILE, bench_id, bytes);
+}
+
+pub fn record_structural_mem<K: Display>(bench_id: K, bytes: usize) {
+    record_line(STRUCTURAL_FILE, bench_id, bytes);
+}
+
+fn record_line<K: Display>(file: &str, bench_id: K, bytes: usize) {
+    let bench_id = bench_id.to_string();
+    let _guard = LOCK.lock().unwrap();
+    let base = Path::new(BASE_DIR);
+    if let Err(err) = create_dir_all(base) {
+        eprintln!("failed to create metric directory: {err}");
+        return;
+    }
+    let path = base.join(file);
+    let existed = path.exists();
+    let file = match OpenOptions::new().create(true).append(true).open(&path) {
+        Ok(file) => file,
+        Err(err) => {
+            eprintln!("failed to open metric csv {}: {err}", path.display());
+            return;
+        }
+    };
+    let mut writer = BufWriter::new(file);
+    if !existed {
+        if let Err(err) = writeln!(writer, "bench_id,bytes") {
+            eprintln!(
+                "failed to write metric header for {}: {err}",
+                path.display()
+            );
+            return;
+        }
+    }
+    if let Err(err) = writeln!(writer, "{bench_id},{bytes}") {
+        eprintln!("failed to record metric row for {}: {err}", path.display());
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared memory recorder for benches that writes CSV metrics for each bench id
- hook existing build-focused benches to record memory usage and register the new memory scaling benchmark
- expose the new benchmark in the manifest so it builds with the bench feature

## Testing
- cargo fmt
- cargo build --all-targets
- cargo test
- cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args

------
https://chatgpt.com/codex/tasks/task_e_68e42fde185c8326a12ec244ca4185fc