### PR TITLE
Run benchmarks in CI

### DIFF
--- a/.github/scripts/bench_summary.py
+++ b/.github/scripts/bench_summary.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import List, Tuple
+
+CRITERION_DIR = Path("target/criterion")
+SUMMARY_PATH = Path(os.environ.get("GITHUB_STEP_SUMMARY", "bench-summary.md"))
+
+
+def format_duration(seconds: float) -> str:
+    if seconds >= 1.0:
+        return f"{seconds:.2f} s"
+    milliseconds = seconds * 1_000.0
+    if milliseconds >= 1.0:
+        return f"{milliseconds:.2f} ms"
+    microseconds = milliseconds * 1_000.0
+    return f"{microseconds:.2f} µs"
+
+
+def collect_estimates() -> List[Tuple[str, float, float]]:
+    if not CRITERION_DIR.exists():
+        return []
+
+    results: List[Tuple[str, float, float]] = []
+    for estimate_path in CRITERION_DIR.rglob("new/estimates.json"):
+        try:
+            data = json.loads(estimate_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        mean = float(data["mean"]["point_estimate"]) / 1_000_000_000.0
+        std_dev = float(data["std_dev"]["point_estimate"]) / 1_000_000_000.0
+        bench_name_parts = estimate_path.relative_to(CRITERION_DIR).parts
+        bench_name = "/".join(bench_name_parts[:-2])
+        results.append((bench_name, mean, std_dev))
+
+    results.sort(key=lambda item: item[0])
+    return results
+
+
+def main() -> None:
+    estimates = collect_estimates()
+    if not estimates:
+        SUMMARY_PATH.write_text("No benchmark results found.\n")
+        return
+
+    lines = ["Benchmark summary", "", "| Benchmark | Mean | Std Dev |", "| --- | --- | --- |"]
+    for name, mean, std_dev in estimates:
+        lines.append(
+            f"| `{name}` | {format_duration(mean)} | {format_duration(std_dev)} |")
+
+    SUMMARY_PATH.write_text("\n".join(lines) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,10 +10,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
           override: true
-      - name: Bench
-        run: cargo bench --all --features bench
+      - name: Run benchmarks
+        env:
+          GZSET_BENCH_MEASUREMENT_SECS: "0.2"
+          GZSET_BENCH_WARMUP_SECS: "0.1"
+          GZSET_BENCH_RAND_SIZE: "500"
+          GZSET_BENCH_RANGE_SIZE: "500"
+          GZSET_BENCH_SCAN_SIZE: "500"
+          GZSET_BENCH_SCAN_CURSOR_SAMPLES: "40"
+          GZSET_BENCH_INSERT_SIZE: "500"
+          GZSET_BENCH_UPDATE_SIZE: "500"
+          GZSET_BENCH_UPDATE_TOUCH: "100"
+          GZSET_BENCH_REMOVE_SIZE: "500"
+          GZSET_BENCH_REMOVE_COUNT: "100"
+          GZSET_BENCH_LOOKUP_SIZE: "500"
+          GZSET_BENCH_QUERY_COUNT: "100"
+          BENCH_ENTRY_COUNT: "500"
+          BENCH_REPEAT_POPS: "10"
+        run: cargo bench --all
+      - name: Summarize benchmarks
+        run: .github/scripts/bench_summary.py

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,57 +16,46 @@ path = "src/bin/xtask.rs"
 [[bench]]
 name = "gzpop"
 harness = false
-required-features = ["bench"]
 
 [[bench]]
 name = "format"
 harness = false
-required-features = ["bench"]
 
 [[bench]]
 name = "gzrange"
 harness = false
-required-features = ["bench"]
 
 [[bench]]
 name = "gzadd_tied"
 harness = false
-required-features = ["bench"]
 
 [[bench]]
 name = "gzadd"
 harness = false
-required-features = ["bench"]
 
 [[bench]]
 name = "gzrem"
 harness = false
-required-features = ["bench"]
 
 [[bench]]
 name = "lookup"
 harness = false
-required-features = ["bench"]
 
 [[bench]]
 name = "gzrand"
 harness = false
-required-features = ["bench"]
 
 [[bench]]
 name = "algebra"
 harness = false
-required-features = ["bench"]
 
 [[bench]]
 name = "gzscan"
 harness = false
-required-features = ["bench"]
 
 [[bench]]
 name = "memory"
 harness = false
-required-features = ["bench"]
 
 [dependencies]
 redis-module = "2.0.7"

--- a/benches/format.rs
+++ b/benches/format.rs
@@ -3,9 +3,11 @@ use gzset::{fmt_f64, with_fmt_buf};
 use redis_module::raw;
 use std::os::raw::{c_char, c_int};
 use std::sync::Once;
+use std::time::Duration;
 
 fn bench_format(c: &mut Criterion) {
     let mut group = c.benchmark_group("fmt_vs_to_string");
+    configure_group(&mut group, 5.0, 3.0, 100);
     group.bench_function("fmt_f64", |b| {
         b.iter(|| {
             for _ in 0..1_000_000 {
@@ -30,6 +32,7 @@ fn bench_reply_methods(c: &mut Criterion) {
     init_reply_stubs();
     let raw_ctx = redis_module::Context::dummy().get_raw();
     let mut group = c.benchmark_group("reply_methods");
+    configure_group(&mut group, 5.0, 3.0, 100);
     group.bench_function("string_buffer_fmt", |b| {
         b.iter(|| {
             for _ in 0..1_000_000 {
@@ -83,3 +86,34 @@ unsafe extern "C" fn reply_with_double_stub(_ctx: *mut raw::RedisModuleCtx, valu
 
 criterion_group!(benches, bench_format, bench_reply_methods);
 criterion_main!(benches);
+
+fn configure_group(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    default_measure: f64,
+    default_warmup: f64,
+    default_samples: usize,
+) {
+    let measurement = duration_env("GZSET_BENCH_MEASUREMENT_SECS", default_measure);
+    let warmup = duration_env("GZSET_BENCH_WARMUP_SECS", default_warmup);
+    let sample_size = sample_size_env("GZSET_BENCH_SAMPLE_SIZE", default_samples);
+    group.measurement_time(measurement);
+    group.warm_up_time(warmup);
+    group.sample_size(sample_size);
+}
+
+fn duration_env(name: &str, default_secs: f64) -> Duration {
+    let secs = std::env::var(name)
+        .ok()
+        .and_then(|s| s.parse::<f64>().ok())
+        .filter(|value| *value >= 0.0)
+        .unwrap_or(default_secs);
+    Duration::from_secs_f64(secs)
+}
+
+fn sample_size_env(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .map(|size| size.max(10))
+        .unwrap_or(default)
+}

--- a/benches/gzadd.rs
+++ b/benches/gzadd.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use criterion::{
     black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput,
 };
@@ -14,9 +12,12 @@ fn bench_insert(c: &mut Criterion) {
     let high_ties_entries = build_high_ties(insert_size);
 
     let mut group = c.benchmark_group("insert");
-    group.measurement_time(Duration::from_secs(10));
-    group.warm_up_time(Duration::from_secs(3));
-    group.sample_size(10);
+    let measurement = support::duration_env("GZSET_BENCH_MEASUREMENT_SECS", 10.0);
+    let warmup = support::duration_env("GZSET_BENCH_WARMUP_SECS", 3.0);
+    let sample_size = support::usize_env("GZSET_BENCH_SAMPLE_SIZE", 10);
+    group.measurement_time(measurement);
+    group.warm_up_time(warmup);
+    group.sample_size(sample_size);
     for (name, entries) in [
         ("unique_increasing", &unique_entries),
         ("uniform_random", &uniform_entries),
@@ -26,7 +27,7 @@ fn bench_insert(c: &mut Criterion) {
         group.throughput(Throughput::Elements(entries.len() as u64));
         group.bench_with_input(dataset, entries, |b, data| {
             b.iter(|| {
-                let mut set = support::build_set(data);
+                let set = support::build_set(data);
                 black_box(set.len());
             });
         });
@@ -59,9 +60,12 @@ fn bench_update(c: &mut Criterion) {
     }
 
     let mut group = c.benchmark_group("update");
-    group.measurement_time(Duration::from_secs(10));
-    group.warm_up_time(Duration::from_secs(3));
-    group.sample_size(10);
+    let measurement = support::duration_env("GZSET_BENCH_MEASUREMENT_SECS", 10.0);
+    let warmup = support::duration_env("GZSET_BENCH_WARMUP_SECS", 3.0);
+    let sample_size = support::usize_env("GZSET_BENCH_SAMPLE_SIZE", 10);
+    group.measurement_time(measurement);
+    group.warm_up_time(warmup);
+    group.sample_size(sample_size);
     group.throughput(Throughput::Elements(nearby_updates.len() as u64));
     group.bench_function("score_move_nearby", |b| {
         b.iter_batched(

--- a/benches/gzadd_tied.rs
+++ b/benches/gzadd_tied.rs
@@ -9,7 +9,12 @@ fn bench_insert_many_ties(c: &mut Criterion) {
         .collect();
 
     let mut group = c.benchmark_group("insert_many_ties");
-    group.sample_size(10);
+    let measurement = support::duration_env("GZSET_BENCH_MEASUREMENT_SECS", 10.0);
+    let warmup = support::duration_env("GZSET_BENCH_WARMUP_SECS", 3.0);
+    let sample_size = support::usize_env("GZSET_BENCH_SAMPLE_SIZE", 10);
+    group.measurement_time(measurement);
+    group.warm_up_time(warmup);
+    group.sample_size(sample_size);
     group.bench_function("insert_many_ties", |b| {
         b.iter(|| {
             let mut set = ScoreSet::default();

--- a/benches/gzpop.rs
+++ b/benches/gzpop.rs
@@ -1,7 +1,7 @@
-use std::time::Duration;
-
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use gzset::ScoreSet;
+
+mod support;
 
 const DEFAULT_ENTRY_COUNT: usize = 100_000;
 const DEFAULT_REPEAT_POPS: usize = 50;
@@ -26,42 +26,45 @@ fn bench_pop(c: &mut Criterion) {
     let members: Vec<String> = (0..entry_count).map(|i| format!("member:{i}")).collect();
 
     let mut group = c.benchmark_group("pop_loop_vs_baseline");
-    group.measurement_time(Duration::from_secs(8));
-    group.warm_up_time(Duration::from_secs(2));
-    group.sample_size(10);
+    let measurement = support::duration_env("GZSET_BENCH_MEASUREMENT_SECS", 8.0);
+    let warmup = support::duration_env("GZSET_BENCH_WARMUP_SECS", 2.0);
+    let sample_size = support::usize_env("GZSET_BENCH_SAMPLE_SIZE", 10);
+    group.measurement_time(measurement);
+    group.warm_up_time(warmup);
+    group.sample_size(sample_size);
 
     let entry_count_throughput = Throughput::Elements(entry_count as u64);
 
-    group.throughput(entry_count_throughput);
+    group.throughput(entry_count_throughput.clone());
     group.bench_function("pop_min", |b| {
         b.iter(|| {
             let mut set = ScoreSet::default();
             for (idx, member) in members.iter().enumerate() {
                 set.insert(idx as f64, member);
             }
-            black_box(set.pop_all(true));
+            black_box(pop_all_members(&mut set, true));
         })
     });
 
-    group.throughput(entry_count_throughput);
+    group.throughput(entry_count_throughput.clone());
     group.bench_function("pop_min_same_score", |b| {
         b.iter(|| {
             let mut set = ScoreSet::default();
             for member in &members {
                 set.insert(0.0, member);
             }
-            black_box(set.pop_all(true));
+            black_box(pop_all_members(&mut set, true));
         })
     });
 
-    group.throughput(entry_count_throughput);
+    group.throughput(entry_count_throughput.clone());
     group.bench_function("pop_max", |b| {
         b.iter(|| {
             let mut set = ScoreSet::default();
             for (idx, member) in members.iter().enumerate() {
                 set.insert(idx as f64, member);
             }
-            black_box(set.pop_all(false));
+            black_box(pop_all_members(&mut set, false));
         })
     });
 
@@ -72,13 +75,13 @@ fn bench_pop(c: &mut Criterion) {
             for member in &members {
                 set.insert(0.0, member);
             }
-            black_box(set.pop_all(false));
+            black_box(pop_all_members(&mut set, false));
         })
     });
 
     let repeat_throughput = Throughput::Elements(repeat_pops as u64);
 
-    group.throughput(repeat_throughput);
+    group.throughput(repeat_throughput.clone());
     group.bench_function("pop_min_n1_same_score", |b| {
         b.iter(|| {
             let mut set = ScoreSet::default();
@@ -92,7 +95,7 @@ fn bench_pop(c: &mut Criterion) {
         })
     });
 
-    group.throughput(repeat_throughput);
+    group.throughput(repeat_throughput.clone());
     group.bench_function("pop_max_n1_same_score", |b| {
         b.iter(|| {
             let mut set = ScoreSet::default();
@@ -106,7 +109,7 @@ fn bench_pop(c: &mut Criterion) {
         })
     });
 
-    group.throughput(repeat_throughput);
+    group.throughput(repeat_throughput.clone());
     group.bench_function("pop_min_one_same_score", |b| {
         b.iter(|| {
             let mut set = ScoreSet::default();
@@ -135,6 +138,13 @@ fn bench_pop(c: &mut Criterion) {
     });
 
     group.finish();
+}
+
+fn pop_all_members(set: &mut ScoreSet, min: bool) -> Vec<String> {
+    set.pop_n(min, set.len())
+        .into_iter()
+        .map(|(member, _)| member)
+        .collect()
 }
 
 criterion_group!(benches, bench_pop);

--- a/benches/gzrange.rs
+++ b/benches/gzrange.rs
@@ -1,7 +1,6 @@
-use std::time::Duration;
-
 use criterion::{
-    black_box, criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode, Throughput,
+    black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkId, Criterion,
+    SamplingMode, Throughput,
 };
 use gzset::ScoreSet;
 
@@ -15,9 +14,12 @@ fn bench_range(c: &mut Criterion) {
     ];
 
     let mut group = c.benchmark_group("gzrange_iter");
-    group.measurement_time(Duration::from_secs(10));
-    group.warm_up_time(Duration::from_secs(3));
-    group.sample_size(10);
+    let measurement = support::duration_env("GZSET_BENCH_MEASUREMENT_SECS", 10.0);
+    let warmup = support::duration_env("GZSET_BENCH_WARMUP_SECS", 3.0);
+    let sample_size = support::usize_env("GZSET_BENCH_SAMPLE_SIZE", 10);
+    group.measurement_time(measurement);
+    group.warm_up_time(warmup);
+    group.sample_size(sample_size);
     group.sampling_mode(SamplingMode::Flat);
 
     for (name, entries) in datasets {
@@ -28,7 +30,7 @@ fn bench_range(c: &mut Criterion) {
 }
 
 fn add_range_benches(
-    group: &mut criterion::BenchmarkGroup<'_, Criterion>,
+    group: &mut criterion::BenchmarkGroup<'_, WallTime>,
     name: &str,
     set: &ScoreSet,
 ) {

--- a/benches/gzrem.rs
+++ b/benches/gzrem.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion, Throughput};
 
 mod support;
@@ -31,9 +29,12 @@ fn bench_remove(c: &mut Criterion) {
     record_remove_delta("cluster_back", &base_entries, &back_targets);
 
     let mut group = c.benchmark_group("remove");
-    group.measurement_time(Duration::from_secs(10));
-    group.warm_up_time(Duration::from_secs(3));
-    group.sample_size(10);
+    let measurement = support::duration_env("GZSET_BENCH_MEASUREMENT_SECS", 10.0);
+    let warmup = support::duration_env("GZSET_BENCH_WARMUP_SECS", 3.0);
+    let sample_size = support::usize_env("GZSET_BENCH_SAMPLE_SIZE", 10);
+    group.measurement_time(measurement);
+    group.warm_up_time(warmup);
+    group.sample_size(sample_size);
     group.throughput(Throughput::Elements(random_targets.len() as u64));
     group.bench_function("random_existing", |b| {
         b.iter_batched(

--- a/benches/gzscan.rs
+++ b/benches/gzscan.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, time::Duration};
+use std::cell::RefCell;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use gzset::{fmt_f64, with_fmt_buf, ScoreSet};
@@ -15,9 +15,12 @@ fn bench_scan(c: &mut Criterion) {
     let cursors = build_cursors(set, cursor_samples);
 
     let mut group = c.benchmark_group("scan");
-    group.measurement_time(Duration::from_secs(10));
-    group.warm_up_time(Duration::from_secs(3));
-    group.sample_size(10);
+    let measurement = support::duration_env("GZSET_BENCH_MEASUREMENT_SECS", 10.0);
+    let warmup = support::duration_env("GZSET_BENCH_WARMUP_SECS", 3.0);
+    let sample_size = support::usize_env("GZSET_BENCH_SAMPLE_SIZE", 10);
+    group.measurement_time(measurement);
+    group.warm_up_time(warmup);
+    group.sample_size(sample_size);
     group.sampling_mode(criterion::SamplingMode::Flat);
     for &count in &[10usize, 100, 1024] {
         group.throughput(Throughput::Elements(count as u64));
@@ -48,7 +51,10 @@ fn build_scan_entries(n: usize) -> Vec<(f64, String)> {
 fn build_cursors(set: &ScoreSet, samples: usize) -> Vec<String> {
     let mut cursors = Vec::with_capacity(samples + 1);
     cursors.push("0".to_string());
-    let members = set.members_with_scores();
+    let members: Vec<(String, f64)> = set
+        .iter_all()
+        .map(|(member, score)| (member.to_owned(), score))
+        .collect();
     let mut rng = support::seeded_rng();
     for _ in 0..samples {
         let idx = rng.gen_range(0..members.len());

--- a/benches/lookup.rs
+++ b/benches/lookup.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 
 mod support;
@@ -15,9 +13,12 @@ fn bench_lookup(c: &mut Criterion) {
         .collect();
 
     let mut group = c.benchmark_group("lookup");
-    group.measurement_time(Duration::from_secs(10));
-    group.warm_up_time(Duration::from_secs(3));
-    group.sample_size(10);
+    let measurement = support::duration_env("GZSET_BENCH_MEASUREMENT_SECS", 10.0);
+    let warmup = support::duration_env("GZSET_BENCH_WARMUP_SECS", 3.0);
+    let sample_size = support::usize_env("GZSET_BENCH_SAMPLE_SIZE", 10);
+    group.measurement_time(measurement);
+    group.warm_up_time(warmup);
+    group.sample_size(sample_size);
     group.throughput(Throughput::Elements(existing.len() as u64));
     group.bench_function("rank/existing_random", |b| {
         b.iter(|| {

--- a/benches/memory.rs
+++ b/benches/memory.rs
@@ -2,9 +2,11 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 mod support;
 
+type DatasetGenerator = fn(usize) -> Vec<(f64, String)>;
+
 fn bench_memory(_: &mut Criterion) {
     const SIZES: [usize; 5] = [10_000, 50_000, 100_000, 500_000, 1_000_000];
-    let datasets: [(&str, fn(usize) -> Vec<(f64, String)>); 3] = [
+    let datasets: [(&str, DatasetGenerator); 3] = [
         ("unique_increasing", support::unique_increasing),
         ("same_score", same_score_dataset),
         ("uniform_random", uniform_random_dataset),

--- a/tests/gzrandmember.rs
+++ b/tests/gzrandmember.rs
@@ -58,12 +58,13 @@ fn gzrandmember_samples() -> redis::RedisResult<()> {
 
     // allow duplicates
     let mut saw_duplicate = false;
+    let sample_size = 60i64; // larger than the set to guarantee duplicates with replacement
     for _ in 0..20 {
         let dup_items: Vec<String> = redis::cmd("GZRANDMEMBER")
             .arg("s")
-            .arg(-5)
+            .arg(-sample_size)
             .query(&mut con)?;
-        assert_eq!(dup_items.len(), 5);
+        assert_eq!(dup_items.len() as i64, sample_size);
         for item in &dup_items {
             assert!(item.starts_with('m'));
         }


### PR DESCRIPTION
## Summary
- remove the `bench` feature requirement so the Criterion suites run with `cargo bench`
- make the benchmark helpers and suites use environment-controlled sizing and public APIs
- add a benchmark workflow and summary script to run `cargo bench` in CI and capture key stats

## Testing
- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args
- cargo test
- GZSET_BENCH_MEASUREMENT_SECS=0.2 GZSET_BENCH_WARMUP_SECS=0.05 GZSET_BENCH_RAND_SIZE=5000 GZSET_BENCH_RANGE_SIZE=10000 GZSET_BENCH_SCAN_SIZE=20000 GZSET_BENCH_SCAN_CURSOR_SAMPLES=64 GZSET_BENCH_INSERT_SIZE=20000 GZSET_BENCH_UPDATE_SIZE=10000 GZSET_BENCH_UPDATE_TOUCH=5000 GZSET_BENCH_REMOVE_SIZE=15000 GZSET_BENCH_REMOVE_COUNT=5000 GZSET_BENCH_LOOKUP_SIZE=20000 GZSET_BENCH_QUERY_COUNT=2000 cargo bench

------
https://chatgpt.com/codex/tasks/task_e_68e6b31d99c08326bd60017e9cd64ba3