### PR TITLE
Streamline gzrand and lookup benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ mem_profile = []
 redis-module = []
 fast-hash = []
 reply-double = []
+bench-internals = []
 
 [profile.release]
 debug = 1

--- a/benches/lookup.rs
+++ b/benches/lookup.rs
@@ -2,12 +2,20 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughpu
 
 mod support;
 
+// The rank benchmarks use a separate query-count knob to keep each sample short
+// enough for Criterion's default measurement window. Override via
+// GZSET_BENCH_QUERY_COUNT_RANK.
 fn bench_lookup(c: &mut Criterion) {
     let lookup_size = support::usize_env("GZSET_BENCH_LOOKUP_SIZE", 200_000);
     let query_count = support::usize_env("GZSET_BENCH_QUERY_COUNT", 10_000);
+    let rank_existing_count = std::env::var("GZSET_BENCH_QUERY_COUNT_RANK")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(3_000);
     let entries = support::uniform_random(lookup_size, lookup_size as f64);
     let set = Box::leak(Box::new(support::build_set(&entries)));
     let existing = support::pick_existing(set, query_count);
+    let rank_existing = &existing[..existing.len().min(rank_existing_count)];
     let missing: Vec<String> = (0..existing.len())
         .map(|i| format!("missing:{i}"))
         .collect();
@@ -19,10 +27,10 @@ fn bench_lookup(c: &mut Criterion) {
     group.measurement_time(measurement);
     group.warm_up_time(warmup);
     group.sample_size(sample_size);
-    group.throughput(Throughput::Elements(existing.len() as u64));
+    group.throughput(Throughput::Elements(rank_existing.len() as u64));
     group.bench_function("rank/existing_random", |b| {
         b.iter(|| {
-            for member in &existing {
+            for member in rank_existing {
                 let res = set.rank(black_box(member.as_str()));
                 black_box(res);
             }
@@ -30,7 +38,7 @@ fn bench_lookup(c: &mut Criterion) {
     });
 
     #[cfg(feature = "bench-internals")]
-    let existing_handles: Vec<_> = existing
+    let existing_handles: Vec<_> = rank_existing
         .iter()
         .map(|member| {
             set.rank_find_only(member.as_str())
@@ -40,10 +48,10 @@ fn bench_lookup(c: &mut Criterion) {
 
     #[cfg(feature = "bench-internals")]
     {
-        group.throughput(Throughput::Elements(existing.len() as u64));
+        group.throughput(Throughput::Elements(rank_existing.len() as u64));
         group.bench_function("rank/find_only", |b| {
             b.iter(|| {
-                for member in &existing {
+                for member in rank_existing {
                     let handle = set
                         .rank_find_only(black_box(member.as_str()))
                         .expect("existing member must resolve");
@@ -52,7 +60,7 @@ fn bench_lookup(c: &mut Criterion) {
             });
         });
 
-        group.throughput(Throughput::Elements(existing.len() as u64));
+        group.throughput(Throughput::Elements(rank_existing.len() as u64));
         group.bench_function("rank/resolve_only", |b| {
             b.iter(|| {
                 for handle in &existing_handles {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,9 @@ pub use crate::{
     score_set::{RangeIterFwd, ScoreIter, ScoreSet},
 };
 
+#[cfg(feature = "bench-internals")]
+pub use crate::score_set::RankFind;
+
 mod buckets;
 mod command;
 mod format;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+//! Bench-only helpers gated behind `bench-internals` (such as `RankFind`) are not
+//! part of the stable public API surface.
 #![deny(clippy::uninlined_format_args, clippy::to_string_in_format_args)]
 
 #[cfg(all(not(test), feature = "redis-module"))]
@@ -12,6 +14,7 @@ pub use crate::{
 };
 
 #[cfg(feature = "bench-internals")]
+#[doc(hidden)]
 pub use crate::score_set::RankFind;
 
 mod buckets;


### PR DESCRIPTION
## Summary
- precompute random index selections for the gzrand count benchmarks so the timed loop only exercises `select_by_rank`
- add a `bench-internals` feature that exposes `ScoreSet::rank_find_only`/`rank_resolve_only` and hook the lookup benchmark into find-only and resolve-only passes
- reduce the default lookup rank query count to keep Criterion sampling quick and avoid warnings

## Testing
- cargo fmt
- cargo test
- cargo clippy --all-targets -- -D warnings -D clippy::uninlined_format_args -D clippy::to_string_in_format_args
- cargo bench --bench lookup --no-run --features bench-internals

------
https://chatgpt.com/codex/tasks/task_e_68e81504cccc832680dc3e14f5fa1c76