### PR TITLE
Add benches for score ranges, top-k selection, churn, and string shapes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,18 @@ harness = false
 name = "memory"
 harness = false
 
+[[bench]]
+name = "gztopk"
+harness = false
+
+[[bench]]
+name = "gzchurn"
+harness = false
+
+[[bench]]
+name = "gzstring"
+harness = false
+
 [dependencies]
 redis-module = "2.0.7"
 once_cell = "1"

--- a/benches/gzchurn.rs
+++ b/benches/gzchurn.rs
@@ -1,0 +1,140 @@
+use criterion::{
+    black_box, criterion_group, criterion_main, BatchSize, Criterion, SamplingMode, Throughput,
+};
+use gzset::ScoreSet;
+use rand::{seq::SliceRandom, Rng};
+
+mod support;
+
+fn bench_churn(c: &mut Criterion) {
+    let base_size = support::usize_env("GZSET_CHURN_BASE", 100_000);
+    let script_len = support::usize_env("GZSET_CHURN_SCRIPT", 50_000);
+    let measurement = support::duration_env("GZSET_BENCH_MEASUREMENT_SECS", 10.0);
+    let warmup = support::duration_env("GZSET_BENCH_WARMUP_SECS", 3.0);
+    let sample_size = support::usize_env("GZSET_BENCH_SAMPLE_SIZE", 10);
+
+    let base_entries = support::uniform_random(base_size, base_size as f64 * 4.0);
+    let script = build_script(&base_entries, script_len);
+
+    let mut group = c.benchmark_group("churn");
+    group.measurement_time(measurement);
+    group.warm_up_time(warmup);
+    group.sample_size(sample_size);
+    group.sampling_mode(SamplingMode::Flat);
+    group.throughput(Throughput::Elements(script.len() as u64));
+
+    group.bench_function("script_mixed", |b| {
+        b.iter_batched(
+            || support::build_set(&base_entries),
+            |mut set| {
+                apply_script(&mut set, &script);
+                black_box(set.len());
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.finish();
+}
+
+#[derive(Clone)]
+enum Operation {
+    Insert { member: String, score: f64 },
+    Update { member: String, score: f64 },
+    Remove { member: String },
+}
+
+#[derive(Clone)]
+struct MemberState {
+    name: String,
+    score: f64,
+}
+
+fn build_script(base_entries: &[(f64, String)], script_len: usize) -> Vec<Operation> {
+    let mut rng = support::seeded_rng();
+    let update_count = script_len * 50 / 100;
+    let insert_count = script_len * 30 / 100;
+    let remove_count = script_len - update_count - insert_count;
+
+    let mut op_types = Vec::with_capacity(script_len);
+    op_types.extend(std::iter::repeat(OpType::Update).take(update_count));
+    op_types.extend(std::iter::repeat(OpType::Insert).take(insert_count));
+    op_types.extend(std::iter::repeat(OpType::Remove).take(remove_count));
+    op_types.shuffle(&mut rng);
+
+    let mut existing: Vec<MemberState> = base_entries
+        .iter()
+        .map(|(score, member)| MemberState {
+            name: member.clone(),
+            score: *score,
+        })
+        .collect();
+    let mut next_insert_id = 0usize;
+    let base_score_span = (base_entries.len().max(1) as f64) * 4.0;
+
+    let mut script = Vec::with_capacity(op_types.len());
+    for op in op_types {
+        match op {
+            OpType::Update => {
+                if existing.is_empty() {
+                    continue;
+                }
+                let idx = rng.gen_range(0..existing.len());
+                let state = &mut existing[idx];
+                let delta = if rng.gen_bool(0.7) {
+                    rng.gen_range(-1.0..=1.0)
+                } else {
+                    rng.gen_range(-750.0..=750.0)
+                };
+                state.score += delta;
+                script.push(Operation::Update {
+                    member: state.name.clone(),
+                    score: state.score,
+                });
+            }
+            OpType::Insert => {
+                let member = format!("new:{next_insert_id}");
+                next_insert_id += 1;
+                let score = rng.gen_range(0.0..base_score_span);
+                existing.push(MemberState {
+                    name: member.clone(),
+                    score,
+                });
+                script.push(Operation::Insert { member, score });
+            }
+            OpType::Remove => {
+                if existing.is_empty() {
+                    continue;
+                }
+                let idx = rng.gen_range(0..existing.len());
+                let state = existing.swap_remove(idx);
+                script.push(Operation::Remove { member: state.name });
+            }
+        }
+    }
+
+    script
+}
+
+fn apply_script(set: &mut ScoreSet, script: &[Operation]) {
+    for op in script {
+        match op {
+            Operation::Insert { member, score } | Operation::Update { member, score } => {
+                set.insert(*score, member);
+            }
+            Operation::Remove { member } => {
+                set.remove(member);
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum OpType {
+    Insert,
+    Update,
+    Remove,
+}
+
+criterion_group!(benches, bench_churn);
+criterion_main!(benches);

--- a/benches/gzrange.rs
+++ b/benches/gzrange.rs
@@ -3,14 +3,25 @@ use criterion::{
     SamplingMode, Throughput,
 };
 use gzset::ScoreSet;
+use ordered_float::OrderedFloat;
 
 mod support;
 
 fn bench_range(c: &mut Criterion) {
     let range_size = support::usize_env("GZSET_BENCH_RANGE_SIZE", 500_000);
+
+    let unique_entries = support::unique_increasing(range_size);
+    let unique_set: &'static ScoreSet = Box::leak(Box::new(support::build_set(&unique_entries)));
+    let same_score_entries = support::same_score(range_size, 42.0);
+    let same_score_set: &'static ScoreSet =
+        Box::leak(Box::new(support::build_set(&same_score_entries)));
+    let clustered_entries = support::clustered(range_size, 8, 4.0);
+    let clustered_set: &'static ScoreSet =
+        Box::leak(Box::new(support::build_set(&clustered_entries)));
+
     let datasets = [
-        ("unique_increasing", support::unique_increasing(range_size)),
-        ("same_score", support::same_score(range_size, 42.0)),
+        ("unique_increasing", unique_set),
+        ("same_score", same_score_set),
     ];
 
     let mut group = c.benchmark_group("gzrange_iter");
@@ -22,11 +33,27 @@ fn bench_range(c: &mut Criterion) {
     group.sample_size(sample_size);
     group.sampling_mode(SamplingMode::Flat);
 
-    for (name, entries) in datasets {
-        let set = Box::leak(Box::new(support::build_set(&entries)));
+    for (name, set) in datasets {
         add_range_benches(&mut group, name, set);
     }
     group.finish();
+
+    let score_datasets = [
+        ("unique_increasing", unique_set),
+        ("same_score", same_score_set),
+        ("clustered", clustered_set),
+    ];
+
+    let mut score_group = c.benchmark_group("gzrange_score");
+    score_group.measurement_time(measurement);
+    score_group.warm_up_time(warmup);
+    score_group.sample_size(sample_size);
+    score_group.sampling_mode(SamplingMode::Flat);
+
+    for (name, set) in score_datasets {
+        add_score_range_benches(&mut score_group, name, set);
+    }
+    score_group.finish();
 }
 
 fn add_range_benches(
@@ -69,6 +96,78 @@ fn add_range_benches(
             }
         });
     });
+}
+
+fn add_score_range_benches(
+    group: &mut criterion::BenchmarkGroup<'_, WallTime>,
+    name: &str,
+    set: &ScoreSet,
+) {
+    let mut ordered: Vec<(OrderedFloat<f64>, &str)> = set
+        .iter_all()
+        .map(|(member, score)| (OrderedFloat(score), member))
+        .collect();
+    if ordered.is_empty() {
+        return;
+    }
+    ordered.sort_unstable();
+
+    let len = ordered.len();
+    let wide_target = ((len as f64) * 0.65).round() as usize;
+    let specs = [
+        ("score/narrow", 1_000usize),
+        ("score/medium", 10_000usize),
+        ("score/wide", wide_target),
+    ];
+
+    for (label, target) in specs {
+        let desired = target.clamp(1, len);
+        let mid = len / 2;
+        let mut start_idx = if desired >= len {
+            0
+        } else {
+            mid.saturating_sub(desired / 2)
+        };
+        let mut end_idx = start_idx + desired - 1;
+        if end_idx >= len {
+            end_idx = len - 1;
+            start_idx = len - desired;
+        }
+
+        let min_score = ordered[start_idx].0 .0;
+        let max_score = ordered[end_idx].0 .0;
+
+        let mut iter = set.iter_from(OrderedFloat(min_score), "", false);
+        let mut count = 0usize;
+        while let Some((_, score)) = iter.next() {
+            if score > max_score {
+                break;
+            }
+            count += 1;
+        }
+
+        if count == 0 {
+            continue;
+        }
+
+        let min_key = OrderedFloat(min_score);
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_function(BenchmarkId::new(label, name), |b| {
+            b.iter(|| {
+                let mut iter = set.iter_from(min_key, "", false);
+                let mut yielded = 0usize;
+                while let Some((member, score)) = iter.next() {
+                    if score > max_score {
+                        break;
+                    }
+                    black_box(member);
+                    black_box(score);
+                    yielded += 1;
+                }
+                black_box(yielded);
+            });
+        });
+    }
 }
 
 criterion_group!(benches, bench_range);

--- a/benches/gzstring.rs
+++ b/benches/gzstring.rs
@@ -1,0 +1,105 @@
+use criterion::{
+    black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, SamplingMode,
+    Throughput,
+};
+use gzset::ScoreSet;
+
+mod support;
+
+fn bench_string_shape(c: &mut Criterion) {
+    let dataset_size = support::usize_env("GZSET_STRING_SHAPE_SIZE", 150_000);
+    let measurement = support::duration_env("GZSET_BENCH_MEASUREMENT_SECS", 10.0);
+    let warmup = support::duration_env("GZSET_BENCH_WARMUP_SECS", 3.0);
+    let sample_size = support::usize_env("GZSET_BENCH_SAMPLE_SIZE", 10);
+    let score_query_count = support::usize_env("GZSET_STRING_SCORE_QUERIES", 5_000);
+    let rank_query_count = support::usize_env("GZSET_STRING_RANK_QUERIES", 1_000);
+
+    let datasets = [
+        ("short_ascii", build_short_ascii(dataset_size)),
+        ("long_prefix", build_long_prefix(dataset_size)),
+        ("utf8_heavy", build_utf8_heavy(dataset_size)),
+    ];
+
+    let mut group = c.benchmark_group("string_shape");
+    group.measurement_time(measurement);
+    group.warm_up_time(warmup);
+    group.sample_size(sample_size);
+    group.sampling_mode(SamplingMode::Flat);
+
+    for (name, entries) in datasets {
+        let set = Box::leak(Box::new(support::build_set(&entries)));
+        let desired = std::cmp::max(score_query_count.min(entries.len()), 1);
+        let score_queries = support::pick_existing(set, desired);
+        let rank_count = std::cmp::max(rank_query_count.min(score_queries.len()), 1);
+        let rank_queries: Vec<String> = score_queries.iter().take(rank_count).cloned().collect();
+
+        group.throughput(Throughput::Elements(entries.len() as u64));
+        group.bench_function(BenchmarkId::new("insert", name), |b| {
+            b.iter_batched(
+                ScoreSet::default,
+                |mut set| {
+                    for (score, member) in &entries {
+                        set.insert(*score, member);
+                    }
+                    black_box(set.len());
+                },
+                BatchSize::LargeInput,
+            );
+        });
+
+        group.throughput(Throughput::Elements(score_queries.len() as u64));
+        group.bench_function(BenchmarkId::new("score", name), |b| {
+            b.iter(|| {
+                for member in &score_queries {
+                    black_box(set.score(member));
+                }
+            });
+        });
+
+        group.throughput(Throughput::Elements(rank_queries.len() as u64));
+        group.bench_function(BenchmarkId::new("rank", name), |b| {
+            b.iter(|| {
+                for member in &rank_queries {
+                    black_box(set.rank(member));
+                }
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn build_short_ascii(n: usize) -> Vec<(f64, String)> {
+    (0..n).map(|i| (i as f64, format!("a{i}"))).collect()
+}
+
+fn build_long_prefix(n: usize) -> Vec<(f64, String)> {
+    (0..n)
+        .map(|i| {
+            let member = format!(
+                "commonprefix/commonprefix/branch/{:08}/leaf/{:08}/trail",
+                i,
+                i.rotate_left(3)
+            );
+            (i as f64, member)
+        })
+        .collect()
+}
+
+fn build_utf8_heavy(n: usize) -> Vec<(f64, String)> {
+    let accents = ["公測", "пример", "canción", "データ", "δοκιμή"];
+    (0..n)
+        .map(|i| {
+            let prefix = accents[i % accents.len()];
+            let member = format!(
+                "{prefix}|🌟%Δ|møøse|条目{:06}|管道{:06}",
+                i,
+                i.rotate_right(5)
+            );
+            (i as f64, member)
+        })
+        .collect()
+}
+
+criterion_group!(benches, bench_string_shape);
+criterion_main!(benches);

--- a/benches/gztopk.rs
+++ b/benches/gztopk.rs
@@ -1,0 +1,67 @@
+use criterion::{
+    black_box, criterion_group, criterion_main, BenchmarkId, Criterion, SamplingMode, Throughput,
+};
+mod support;
+
+fn bench_topk(c: &mut Criterion) {
+    let base_size = support::usize_env("GZSET_TOPK_SIZE", 200_000);
+    let measurement = support::duration_env("GZSET_BENCH_MEASUREMENT_SECS", 10.0);
+    let warmup = support::duration_env("GZSET_BENCH_WARMUP_SECS", 3.0);
+    let sample_size = support::usize_env("GZSET_BENCH_SAMPLE_SIZE", 10);
+
+    let uniform_entries = support::uniform_random(base_size, base_size as f64 * 4.0);
+    let uniform_set = Box::leak(Box::new(support::build_set(&uniform_entries)));
+    let tie_entries = support::same_score(base_size, 128.0);
+    let tie_set = Box::leak(Box::new(support::build_set(&tie_entries)));
+
+    let datasets = [("uniform_random", uniform_set), ("same_score", tie_set)];
+    let ks = [10usize, 1_000, 10_000];
+
+    let mut group = c.benchmark_group("topk");
+    group.measurement_time(measurement);
+    group.warm_up_time(warmup);
+    group.sample_size(sample_size);
+    group.sampling_mode(SamplingMode::Flat);
+
+    for (name, set) in datasets {
+        let len = set.len();
+        for &k in &ks {
+            let k = k.min(len);
+            if k == 0 {
+                continue;
+            }
+
+            let top_indices: Vec<usize> = (len - k..len).collect();
+            let bottom_indices: Vec<usize> = (0..k).collect();
+
+            group.throughput(Throughput::Elements(k as u64));
+            group.bench_function(BenchmarkId::new(format!("top/{k}"), name), |b| {
+                let mut results = vec![0.0f64; k];
+                b.iter(|| {
+                    for (slot, &rank) in top_indices.iter().enumerate() {
+                        let (_, score) = set.select_by_rank(rank);
+                        results[slot] = score;
+                    }
+                    black_box(&results);
+                });
+            });
+
+            group.throughput(Throughput::Elements(k as u64));
+            group.bench_function(BenchmarkId::new(format!("bottom/{k}"), name), |b| {
+                let mut results = vec![0.0f64; k];
+                b.iter(|| {
+                    for (slot, &rank) in bottom_indices.iter().enumerate() {
+                        let (_, score) = set.select_by_rank(rank);
+                        results[slot] = score;
+                    }
+                    black_box(&results);
+                });
+            });
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_topk);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- extend `gzrange` benches with score-bound iteration coverage across multiple data distributions
- add Criterion benches for non-mutating top/bottom-K selection and mixed update/insert/remove churn workloads
- introduce string-shape sensitivity benchmarks and register the new bench targets in Cargo metadata

## Testing
- `cargo check --benches`


------
https://chatgpt.com/codex/tasks/task_e_68e94acb57dc8326a08cf75493953721