### PR TITLE
Optimize algebra union benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ redis-module = []
 fast-hash = []
 reply-double = []
 bench-internals = []
+bench-borrowed = []
 
 [profile.release]
 debug = 1


### PR DESCRIPTION
## Summary
- reserve the aggregated capacity for `union_multi` once before iterating
- add a borrowed `union/multikey/6sets_borrowed` bench variant behind the `bench-borrowed` feature flag

## Testing
- cargo fmt
- cargo test
- cargo bench --bench algebra --features bench-borrowed --no-run

------
https://chatgpt.com/codex/tasks/task_e_68e95e705c1083269a0711fd4f29ef3d