### PR TITLE
Stop running benches in CI test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,5 +40,5 @@ jobs:
         run: cargo tree -d
         shell: bash
       - name: Test
-        run: cargo test --all --all-targets --verbose
+        run: cargo test --all --verbose
         shell: bash


### PR DESCRIPTION
## Summary
- update the CI test job to run `cargo test` without the `--all-targets` flag so benches are no longer executed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e96137d3dc8326b8b381ab9d5d431f